### PR TITLE
Make shell installer work without xz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-27
+
+### Fixed
+
+- Install the macOS/Linux release binary directly so the shell installer also
+  works on minimal systems without `tar` and `xz` installed.
+
 ## [0.1.1] - 2026-07-27
 
 ### Fixed
@@ -51,7 +58,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/wiedymi/shu/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/wiedymi/shu/compare/v0.1.0...v0.1.1
 [0.1.0-rc.3]: https://github.com/wiedymi/shu/compare/v0.1.0-rc.2...v0.1.0-rc.3
 [0.1.0-rc.1]: https://github.com/wiedymi/shu/releases/tag/v0.1.0-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cargo build --release --locked
 
 FROM debian:bookworm-slim
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends ca-certificates git xz-utils \
+    && apt-get install --yes --no-install-recommends ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /src/target/release/shu /usr/local/bin/shu
 ENTRYPOINT ["shu"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,9 @@ case "$(uname -m)" in
 esac
 
 target="${architecture}-${operating_system}"
-asset="shu-${target}.tar.xz"
+# Releases also publish an uncompressed executable. Installing it directly
+# avoids requiring tar or xz on otherwise clean Linux machines.
+asset="shu-${target}"
 if [ "$version" = "latest" ]; then
     download_base="https://github.com/${repository}/releases/latest/download"
 else
@@ -51,10 +53,10 @@ fi
 
 temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/shu.XXXXXX")"
 trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
-archive="$temporary_directory/$asset"
+binary="$temporary_directory/shu"
 checksums="$temporary_directory/SHA256SUMS"
 info "Downloading $asset"
-download "$download_base/$asset" "$archive"
+download "$download_base/$asset" "$binary"
 info "Downloading SHA256SUMS"
 download "$download_base/SHA256SUMS" "$checksums"
 
@@ -65,19 +67,18 @@ if [ -z "$expected" ]; then
     exit 1
 fi
 if command -v sha256sum >/dev/null 2>&1; then
-    actual="$(sha256sum "$archive" | awk '{ print $1 }')"
+    actual="$(sha256sum "$binary" | awk '{ print $1 }')"
 else
-    actual="$(shasum -a 256 "$archive" | awk '{ print $1 }')"
+    actual="$(shasum -a 256 "$binary" | awk '{ print $1 }')"
 fi
 if [ "$expected" != "$actual" ]; then
     echo "error: checksum verification failed for $asset" >&2
     exit 1
 fi
 
-info "Extracting"
-tar -xJf "$archive" -C "$temporary_directory"
+info "Installing"
 mkdir -p "$install_dir"
-install -m 755 "$temporary_directory/shu" "$install_dir/shu"
+install -m 755 "$binary" "$install_dir/shu"
 success "Installed Shu to $install_dir/shu"
 case ":${PATH}:" in
     *":${install_dir}:"*) ;;

--- a/tests/docker/e2e.sh
+++ b/tests/docker/e2e.sh
@@ -40,8 +40,8 @@ shu --catalog "$workspace/shu.toml" --json list | grep -q '"observed_state": "pr
 # release payload. The fake curl command gives the installer the same
 # command-line contract it has when downloading a GitHub Release.
 mkdir -p "$workspace/release-assets" "$workspace/fake-bin" "$workspace/installed"
-tar -C /usr/local/bin -cJf "$workspace/release-assets/shu-x86_64-unknown-linux-musl.tar.xz" shu
-(cd "$workspace/release-assets" && sha256sum shu-x86_64-unknown-linux-musl.tar.xz > SHA256SUMS)
+cp /usr/local/bin/shu "$workspace/release-assets/shu-x86_64-unknown-linux-musl"
+(cd "$workspace/release-assets" && sha256sum shu-x86_64-unknown-linux-musl > SHA256SUMS)
 cat > "$workspace/fake-bin/curl" <<'EOF'
 #!/bin/sh
 set -eu


### PR DESCRIPTION
Install the checksummed standalone macOS/Linux release binary directly, so a clean system does not need tar or xz. The Docker end-to-end test now proves that minimal environment.