### PR TITLE
Improve first-run and PowerShell experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-27
+
+### Added
+
+- `shu edit <repository>` for changing a catalog entry's lifecycle state and
+  note without touching repository files.
+- `pwsh` as an alias for `shu shell init powershell`.
+
+### Changed
+
+- Create an empty catalog automatically for everyday commands instead of
+  blocking first use on `shu init`.
+- Make `shu status` explain a missing repository's expected path and the exact
+  `shu ensure` command that restores it.
+- Render human errors consistently with a colored heading, an optional cause,
+  and a help line when attached to a terminal.
+- Refactor repository identity parsing into small, documented parsing and
+  validation steps.
+
+### Fixed
+
+- Document and test the PowerShell setup expression so generated shell code is
+  evaluated as one script rather than an array of output lines.
+- Explain the common `shu update . --state ...` mix-up and point to `shu edit`.
+
 ## [0.1.2] - 2026-07-27
 
 ### Fixed
@@ -58,7 +83,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/wiedymi/shu/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/wiedymi/shu/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/wiedymi/shu/compare/v0.1.0...v0.1.1
 [0.1.0-rc.3]: https://github.com/wiedymi/shu/compare/v0.1.0-rc.2...v0.1.0-rc.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ shu restore github.com/your-name/your-repository-library
 ```
 
 Shu reads the repository's root-level `shu.toml`, puts missing repositories
-under `~/shu` by default, and leaves existing repositories alone.
+under `~/shu` by default, and leaves existing repositories alone. If you start
+with an empty machine, everyday commands create an empty local catalog for you.
 
 ## Install
 
@@ -67,6 +68,7 @@ shu status              # See what is present, missing, or uncatalogued
 shu restore             # Clone catalogued repositories that are missing
 shu doctor              # Check Git, the catalog, and the configured root
 shu ensure my-project   # Ensure one repository exists and print its path
+shu edit my-project --state parked --note "Paused until the next release"
 ```
 
 To make bare `shu` open the picker, add its small shell wrapper once:
@@ -80,7 +82,7 @@ shu shell init fish | source
 ```
 
 ```powershell
-Invoke-Expression (& shu shell init powershell)
+Invoke-Expression ((& shu shell init pwsh) -join [Environment]::NewLine)
 ```
 
 For scripts and agents:
@@ -105,6 +107,16 @@ note = "A project I work on regularly"
 The catalog is deliberately data-only: no secrets, setup hooks, or arbitrary
 commands. Shu never deletes repositories, resets a working tree, or overwrites
 a conflicting directory.
+
+When `shu status` says a repository is **missing**, it means the canonical
+clone is not yet under Shu's configured root. It prints the expected path and
+the exact `shu ensure <repository>` command to create it. To update catalog
+metadata without changing repository files:
+
+```sh
+shu edit my-project --state reference --note "Useful implementation reference"
+shu edit my-project --clear-note
+```
 
 ## Updating
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -58,6 +58,26 @@ pub fn load(cli: &Cli) -> Result<(PathBuf, Catalog)> {
     Ok((path, catalog))
 }
 
+/// Load the active catalog, creating an empty one when it has not been set up yet.
+///
+/// This is used by everyday commands so a first run feels ready immediately.
+/// Diagnostic commands keep using [`load`] so they can report a missing catalog
+/// without changing the machine.
+pub fn load_or_initialize(cli: &Cli) -> Result<(PathBuf, Catalog)> {
+    let path = catalog_path(cli)?;
+    if !path.exists() {
+        save(
+            &path,
+            &Catalog {
+                version: 1,
+                root: crate::model::default_root(),
+                repos: vec![],
+            },
+        )?;
+    }
+    load(cli)
+}
+
 /// Serialize a catalog to TOML, creating its parent directory when necessary.
 pub fn save(path: &Path, catalog: &Catalog) -> Result<()> {
     let parent = path

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,6 +53,8 @@ pub enum Commands {
     Init,
     /// Add a repository identity or the current Git repository to the catalog.
     Add(AddArgs),
+    /// Change repository metadata such as its lifecycle state or note.
+    Edit(EditArgs),
     /// Discover Git repositories below a directory.
     Scan(ScanArgs),
     /// Check whether Git, the catalog, repository root, and source setup are ready to use.
@@ -62,7 +64,10 @@ pub enum Commands {
     /// Load a catalog source if provided, then clone missing repositories.
     Restore(RestoreArgs),
     /// Refresh the configured catalog source and restore any newly missing repositories.
-    Update,
+    #[command(
+        after_help = "To edit a repository's metadata, use `shu edit <repository> --state <state>` or `shu edit <repository> --note <text>`."
+    )]
+    Update(UpdateArgs),
     /// Download and install the latest verified Shu binary from GitHub Releases.
     Upgrade(UpgradeArgs),
     /// Ensure a catalogued repository exists locally and print its path.
@@ -98,6 +103,22 @@ pub struct AddArgs {
     /// Optional human-readable context for the repository.
     #[arg(long)]
     pub note: Option<String>,
+}
+
+/// Arguments for `shu edit`.
+#[derive(Args)]
+pub struct EditArgs {
+    /// Full identity, unique suffix, repository name, or local repository path.
+    pub selector: String,
+    /// New lifecycle state to record.
+    #[arg(long, value_enum)]
+    pub state: Option<Lifecycle>,
+    /// Replace the existing note with this human-readable context.
+    #[arg(long, conflicts_with = "clear_note")]
+    pub note: Option<String>,
+    /// Remove the existing note.
+    #[arg(long)]
+    pub clear_note: bool,
 }
 
 /// Arguments for `shu scan`.
@@ -145,6 +166,20 @@ pub struct RestoreArgs {
     /// Limit restoration to a tag or lifecycle state.
     #[command(flatten)]
     pub filter: FilterArgs,
+}
+
+/// Compatibility arguments that let `shu update` explain a common command mix-up.
+#[derive(Args, Default)]
+pub struct UpdateArgs {
+    /// Repository selector accidentally supplied to the catalog refresh command.
+    #[arg(value_name = "REPOSITORY", hide = true)]
+    pub selector: Option<String>,
+    /// Lifecycle state accidentally supplied to the catalog refresh command.
+    #[arg(long, value_enum, hide = true)]
+    pub state: Option<Lifecycle>,
+    /// Repository note accidentally supplied to the catalog refresh command.
+    #[arg(long, hide = true)]
+    pub note: Option<String>,
 }
 
 /// Arguments for `shu upgrade`.
@@ -245,7 +280,7 @@ pub enum Shell {
     /// Fish shell syntax.
     Fish,
     /// PowerShell syntax.
-    #[value(name = "powershell")]
+    #[value(name = "powershell", alias = "pwsh")]
     Power,
     /// Nushell syntax.
     Nushell,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,7 +8,7 @@ mod shell;
 mod upgrade;
 mod view;
 
-pub use catalog::{add, change_state, forget, init, scan};
+pub use catalog::{add, change_state, edit, forget, init, scan};
 pub use doctor::doctor;
 pub use pick::pick;
 pub use restore::{ensure, path_command, restore, update};

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 use crate::{
     catalog::{self, catalog_path},
-    cli::{AddArgs, Cli, ScanArgs, SelectorArgs},
+    cli::{AddArgs, Cli, EditArgs, ScanArgs, SelectorArgs},
     git,
     identity::normalize_identity,
     model::{Catalog, Lifecycle, Repo},
@@ -39,14 +39,17 @@ pub fn init(cli: &Cli) -> Result<()> {
 
 /// Add an identity or the current Git repository to the active catalog.
 pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
-    let (path, mut catalog) = catalog::load(cli)?;
+    let (path, mut catalog) = catalog::load_or_initialize(cli)?;
     let identity = normalize_identity(&catalog::source_from_argument(&args.source)?)?;
-    if catalog
+    if let Some(existing) = catalog
         .repos
         .iter()
-        .any(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(&identity))
+        .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(&identity))
     {
-        bail!("{identity} is already in the catalog");
+        bail!(
+            "{identity} is already in the catalog. To change its state or note, run `shu edit {} --state <state> --note <text>`",
+            catalog::repo_name(existing)
+        );
     }
     catalog.repos.push(Repo {
         source: identity.clone(),
@@ -56,6 +59,36 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     });
     catalog::save(&path, &catalog)?;
     println!("Added {identity}");
+    Ok(())
+}
+
+/// Change the explicit lifecycle state or note for an existing catalog entry.
+pub fn edit(cli: &Cli, args: &EditArgs) -> Result<()> {
+    if args.state.is_none() && args.note.is_none() && !args.clear_note {
+        bail!("nothing to edit; provide --state, --note, or --clear-note");
+    }
+    let (path, mut catalog) = catalog::load_or_initialize(cli)?;
+    let index = catalog::select_index(&catalog, &args.selector)?;
+    let repo = &mut catalog.repos[index];
+    if let Some(state) = args.state {
+        repo.state = state;
+    }
+    if let Some(note) = &args.note {
+        repo.note = Some(note.clone());
+    } else if args.clear_note {
+        repo.note = None;
+    }
+    let name = catalog::repo_name(repo).to_owned();
+    let state = repo.state;
+    let note = repo.note.clone();
+    catalog::save(&path, &catalog)?;
+
+    println!("Updated {name}");
+    println!("  State: {state}");
+    match note {
+        Some(note) => println!("  Note:  {note}"),
+        None => println!("  Note:  none"),
+    }
     Ok(())
 }
 
@@ -85,7 +118,7 @@ pub fn scan(cli: &Cli, args: &ScanArgs) -> Result<()> {
 
 /// Update a lifecycle field only; no repository files are touched.
 pub fn change_state(cli: &Cli, selector: &str, state: Lifecycle) -> Result<()> {
-    let (path, mut catalog) = catalog::load(cli)?;
+    let (path, mut catalog) = catalog::load_or_initialize(cli)?;
     let index = catalog::select_index(&catalog, selector)?;
     catalog.repos[index].state = state;
     let name = catalog::repo_name(&catalog.repos[index]).to_owned();
@@ -96,7 +129,7 @@ pub fn change_state(cli: &Cli, selector: &str, state: Lifecycle) -> Result<()> {
 
 /// Remove a catalog entry while leaving any local clone intact.
 pub fn forget(cli: &Cli, args: &SelectorArgs) -> Result<()> {
-    let (path, mut catalog) = catalog::load(cli)?;
+    let (path, mut catalog) = catalog::load_or_initialize(cli)?;
     let index = catalog::select_index(&catalog, &args.selector)?;
     let removed = catalog.repos.remove(index);
     catalog::save(&path, &catalog)?;
@@ -137,7 +170,7 @@ pub(super) fn discover_repos(root: &Path) -> Result<Vec<(PathBuf, String)>> {
 
 /// Add only identities that are not already in the catalog.
 fn import_discovered(cli: &Cli, found: &[(PathBuf, String)]) -> Result<()> {
-    let (path, mut catalog) = catalog::load(cli)?;
+    let (path, mut catalog) = catalog::load_or_initialize(cli)?;
     let mut known: HashSet<String> = catalog
         .repos
         .iter()

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use crossterm::{
     cursor::{Hide, MoveTo, Show},
     event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
@@ -26,12 +26,17 @@ const MAX_VISIBLE_RESULTS: usize = 12;
 
 /// Interactively select a present local repository with Shu's built-in fuzzy picker.
 pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let candidates = catalog::filtered(&catalog, &args.filter)
         .filter_map(|repo| candidate(&catalog, repo).transpose())
         .collect::<Result<Vec<_>>>()?;
     if candidates.is_empty() {
-        bail!("no catalogued repositories are present locally");
+        if !args.path_only {
+            eprintln!("No catalogued repositories are available locally yet.");
+            eprintln!("  Add the current repository:  shu add .");
+            eprintln!("  Restore a saved library:     shu restore <source>");
+        }
+        return Ok(());
     }
 
     let selected = if let Some(query) = &args.filter_query {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::{
     catalog::{self, catalog_path, repo_name},
-    cli::{Cli, EnsureArgs, FilterArgs, RestoreArgs, SelectorArgs},
+    cli::{Cli, EnsureArgs, FilterArgs, RestoreArgs, SelectorArgs, UpdateArgs},
     git,
     model::{Catalog, Origin},
     paths::{absolute, repo_path, root_path},
@@ -22,7 +22,7 @@ pub fn restore(cli: &Cli, args: &RestoreArgs) -> Result<()> {
     if let Some(source) = &args.source {
         activate_source(cli, args, source)?;
     }
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let repos = catalog::filtered(&catalog, &args.filter).collect::<Vec<_>>();
     if !confirm_restore(cli, args, repos.len())? {
         println!("No changes made.");
@@ -45,7 +45,13 @@ pub fn restore(cli: &Cli, args: &RestoreArgs) -> Result<()> {
 }
 
 /// Refresh the remembered remote source, then restore the refreshed catalog.
-pub fn update(cli: &Cli) -> Result<()> {
+pub fn update(cli: &Cli, args: &UpdateArgs) -> Result<()> {
+    if args.selector.is_some() || args.state.is_some() || args.note.is_some() {
+        let selector = args.selector.as_deref().unwrap_or("<repository>");
+        bail!(
+            "`shu update` refreshes the saved catalog source; it does not edit a repository. Use `shu edit {selector} --state <state> --note <text>` instead"
+        );
+    }
     let origin: Origin = serde_json::from_slice(
         &fs::read(catalog::origin_path(cli)?)
             .context("no saved catalog source; run `shu restore <source>` first")?,
@@ -63,7 +69,7 @@ pub fn update(cli: &Cli) -> Result<()> {
 
 /// Ensure one selected repository exists and print its absolute canonical path.
 pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let repo = catalog::select(&catalog, &args.selector)?;
     let target = repo_path(&catalog, repo)?;
     if !git::is_repo(&target) {
@@ -87,7 +93,7 @@ pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
 
 /// Print a selected repository's path only when it already exists locally.
 pub fn path_command(cli: &Cli, args: &SelectorArgs) -> Result<()> {
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let repo = catalog::select(&catalog, &args.selector)?;
     let target = repo_path(&catalog, repo)?;
     if !git::is_repo(&target) {

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -15,13 +15,14 @@ use crate::{
     identity::normalize_identity,
     model::{Catalog, ListOutput, Repo, RepoOutput},
     paths::{absolute, repo_path, root_path},
+    ui,
 };
 
 use super::catalog::discover_repos;
 
 /// Compare declared catalog state against repositories detected locally.
 pub fn status(cli: &Cli, filter: &FilterArgs) -> Result<()> {
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let repos = catalog::filtered(&catalog, filter).collect::<Vec<_>>();
     if cli.json {
         return print_json(&catalog, repos);
@@ -34,7 +35,7 @@ pub fn status(cli: &Cli, filter: &FilterArgs) -> Result<()> {
 
 /// List filtered entries in a compact one-line format or as JSON.
 pub fn list(cli: &Cli, args: &ListArgs) -> Result<()> {
-    let (_, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load_or_initialize(cli)?;
     let max_age = args.stale.as_deref().map(parse_duration).transpose()?;
     let repos = catalog::filtered(&catalog, &args.filter)
         .filter(|repo| {
@@ -102,17 +103,45 @@ fn print_json(catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
 
 /// Print lifecycle sections and local state for each selected repository.
 fn print_grouped_status(catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
+    if repos.is_empty() {
+        println!("No repositories are catalogued yet.");
+        println!("  Add the current repository:  shu add .");
+        println!("  Restore a saved library:     shu restore <source>");
+        return Ok(());
+    }
+
     let mut current = None;
     for repo in repos {
         if current != Some(repo.state) {
             current = Some(repo.state);
             println!("{}", repo.state.to_string().to_uppercase());
         }
-        println!(
-            "  {:<18} {}",
-            repo_name(repo),
-            observed_state(catalog, repo)?
-        );
+        print_repository_status(catalog, repo)?;
+    }
+    println!("\nEdit metadata: shu edit <repository> --state <state> --note <text>");
+    Ok(())
+}
+
+/// Print one status entry with the expected path and next action when missing.
+fn print_repository_status(catalog: &Catalog, repo: &Repo) -> Result<()> {
+    let observed = observed_state(catalog, repo)?;
+    let marker = match observed.as_str() {
+        value if value.starts_with("present") => ui::success_marker(),
+        "missing" => ui::warning_marker(),
+        _ => ui::failure_marker(),
+    };
+    println!("  {marker} {:<18} {observed}", repo_name(repo));
+
+    if observed == "missing" {
+        let path = absolute(&repo_path(catalog, repo)?)?;
+        println!("    Expected: {}", path.display());
+        println!("    Clone:    shu ensure {}", repo_name(repo));
+    }
+    if let Some(note) = &repo.note {
+        println!("    Note:     {note}");
+    }
+    if !repo.tags.is_empty() {
+        println!("    Tags:     {}", repo.tags.join(", "));
     }
     Ok(())
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,44 +1,112 @@
-//! Normalization for common HTTPS and SSH Git remote formats.
+//! Normalization for the Git remote formats Shu accepts.
 
 use anyhow::{Context, Result, anyhow, bail};
 
-/// Normalize a common Git remote form into `host/namespace/repository`.
+/// Normalize a Git remote or shorthand into `host/namespace/repository`.
 ///
-/// HTTPS, SSH URL, SCP-style SSH, and already-normalized forms are accepted.
-/// Transport-specific syntax and a final `.git` suffix are removed.
+/// HTTPS URLs, SSH URLs, SCP-style SSH remotes, and already-normalized values
+/// are accepted. Transport syntax and a final `.git` suffix are removed.
 pub fn normalize_identity(input: &str) -> Result<String> {
-    let raw = input.trim().trim_end_matches('/').trim_end_matches(".git");
-    let (host, path) = if let Some(rest) = raw.strip_prefix("git@") {
-        let (host, path) = rest
-            .split_once(':')
-            .ok_or_else(|| anyhow!("invalid SSH Git URL: {input}"))?;
-        (host.to_owned(), path.to_owned())
-    } else if raw.contains("://") {
-        let url = url::Url::parse(raw).with_context(|| format!("invalid URL: {input}"))?;
-        (
-            url.host_str()
-                .ok_or_else(|| anyhow!("Git URL has no host: {input}"))?
-                .to_owned(),
-            url.path().trim_matches('/').to_owned(),
-        )
-    } else {
-        let parts = raw.trim_matches('/').split('/').collect::<Vec<_>>();
-        if parts.len() < 3 {
-            bail!("repository identity must be host/namespace/repository: {input}");
-        }
-        (parts[0].to_owned(), parts[1..].join("/"))
-    };
-    let path = path.trim_matches('/').trim_end_matches(".git");
-    let valid_host =
-        !host.is_empty() && !host.contains(['/', '\\']) && host.split('.').all(valid_component);
-    let path_parts = path.split('/').collect::<Vec<_>>();
-    if !valid_host || path_parts.len() < 2 || !path_parts.iter().all(|part| valid_component(part)) {
-        bail!("invalid repository identity: {input}");
-    }
-    Ok(format!("{}/{}", host.to_ascii_lowercase(), path))
+    let raw = trim_remote_suffix(input);
+    let identity = parse_identity(raw, input)?;
+    validate_identity(&identity, input)?;
+    Ok(identity.render())
 }
 
-/// Return whether one host or repository-path component is safe to place in a path.
+/// The host and repository path extracted from one supported remote format.
+struct ParsedIdentity {
+    /// Remote host, before lowercasing for canonical output.
+    host: String,
+    /// Namespace and repository components, without transport syntax.
+    path: String,
+}
+
+impl ParsedIdentity {
+    /// Render this parsed value in Shu's canonical identity format.
+    fn render(self) -> String {
+        format!("{}/{}", self.host.to_ascii_lowercase(), self.path)
+    }
+}
+
+/// Remove whitespace, a trailing slash, and one conventional Git suffix.
+fn trim_remote_suffix(input: &str) -> &str {
+    input.trim().trim_end_matches('/').trim_end_matches(".git")
+}
+
+/// Parse one of Shu's supported remote forms into host and repository path.
+fn parse_identity(raw: &str, original: &str) -> Result<ParsedIdentity> {
+    if let Some(remote) = raw.strip_prefix("git@") {
+        parse_scp_remote(remote, original)
+    } else if raw.contains("://") {
+        parse_url_remote(raw, original)
+    } else {
+        parse_shorthand(raw, original)
+    }
+}
+
+/// Parse a Git SCP-style remote such as `git@github.com:owner/project`.
+fn parse_scp_remote(remote: &str, original: &str) -> Result<ParsedIdentity> {
+    let (host, path) = remote
+        .split_once(':')
+        .ok_or_else(|| anyhow!("invalid SSH Git URL: {original}"))?;
+    Ok(ParsedIdentity {
+        host: host.to_owned(),
+        path: path.trim_matches('/').trim_end_matches(".git").to_owned(),
+    })
+}
+
+/// Parse a standard URL such as `https://github.com/owner/project`.
+fn parse_url_remote(raw: &str, original: &str) -> Result<ParsedIdentity> {
+    let url = url::Url::parse(raw).with_context(|| format!("invalid URL: {original}"))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("Git URL has no host: {original}"))?;
+    Ok(ParsedIdentity {
+        host: host.to_owned(),
+        path: url
+            .path()
+            .trim_matches('/')
+            .trim_end_matches(".git")
+            .to_owned(),
+    })
+}
+
+/// Parse the plain `host/namespace/repository` form used in catalogs.
+fn parse_shorthand(raw: &str, original: &str) -> Result<ParsedIdentity> {
+    let (host, path) = raw.trim_matches('/').split_once('/').ok_or_else(|| {
+        anyhow!("repository identity must be host/namespace/repository: {original}")
+    })?;
+    if !path.contains('/') {
+        bail!("repository identity must be host/namespace/repository: {original}");
+    }
+    Ok(ParsedIdentity {
+        host: host.to_owned(),
+        path: path.trim_matches('/').trim_end_matches(".git").to_owned(),
+    })
+}
+
+/// Reject incomplete or path-unsafe parsed identities before they reach the filesystem.
+fn validate_identity(identity: &ParsedIdentity, original: &str) -> Result<()> {
+    if !valid_host(&identity.host) || !valid_repository_path(&identity.path) {
+        bail!("invalid repository identity: {original}");
+    }
+    Ok(())
+}
+
+/// Return whether a host is non-empty, path-free, and made of safe labels.
+fn valid_host(host: &str) -> bool {
+    !host.is_empty() && !host.contains(['/', '\\']) && host.split('.').all(valid_component)
+}
+
+/// Return whether a repository path contains at least namespace and repository components.
+fn valid_repository_path(path: &str) -> bool {
+    let mut parts = path.split('/');
+    parts.next().is_some_and(valid_component)
+        && parts.next().is_some_and(valid_component)
+        && parts.all(valid_component)
+}
+
+/// Return whether a single identity component is safe to use below the repository root.
 fn valid_component(value: &str) -> bool {
     !value.is_empty() && value != "." && value != ".." && !value.contains('\\')
 }
@@ -46,6 +114,7 @@ fn valid_component(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn normalizes_common_remote_forms() {
         for value in [
@@ -60,6 +129,7 @@ mod tests {
             );
         }
     }
+
     #[test]
     fn rejects_short_identity() {
         assert!(normalize_identity("acme/widgets").is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ mod model;
 mod paths;
 /// Loading catalogs from files, URLs, Gists, and Git repositories.
 mod sources;
+/// Consistent terminal output for people and scripts.
+mod ui;
 
 use anyhow::Result;
 use clap::Parser;
@@ -35,7 +37,7 @@ use cli::{Cli, Commands};
 /// Run the CLI and render any error as a concise diagnostic.
 fn main() {
     if let Err(error) = run() {
-        eprintln!("error: {error:#}");
+        ui::render_error(&error);
         std::process::exit(1);
     }
 }
@@ -47,11 +49,12 @@ fn run() -> Result<()> {
         None => commands::pick(&cli, &Default::default()),
         Some(Commands::Init) => commands::init(&cli),
         Some(Commands::Add(args)) => commands::add(&cli, args),
+        Some(Commands::Edit(args)) => commands::edit(&cli, args),
         Some(Commands::Scan(args)) => commands::scan(&cli, args),
         Some(Commands::Doctor(args)) => commands::doctor(&cli, args),
         Some(Commands::Status(filter)) => commands::status(&cli, filter),
         Some(Commands::Restore(args)) => commands::restore(&cli, args),
-        Some(Commands::Update) => commands::update(&cli),
+        Some(Commands::Update(args)) => commands::update(&cli, args),
         Some(Commands::Upgrade(args)) => commands::upgrade(args),
         Some(Commands::Ensure(args)) => commands::ensure(&cli, args),
         Some(Commands::Path(args)) => commands::path_command(&cli, args),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,55 @@
+//! Small, consistent terminal presentation helpers.
+//!
+//! Shu keeps command output plain enough to read in logs and scripts while
+//! adding color only when the receiving stream is an interactive terminal.
+
+use std::io::{IsTerminal, stderr, stdout};
+
+use anyhow::Error;
+use crossterm::style::{Color, Stylize};
+
+/// Render a concise error with its immediate underlying cause when available.
+pub fn render_error(error: &Error) {
+    eprintln!(
+        "{} {error}",
+        label("error", Color::Red, stderr().is_terminal())
+    );
+    let mut causes = error.chain();
+    let _ = causes.next();
+    if let Some(cause) = causes.next()
+        && cause.to_string() != error.to_string()
+    {
+        eprintln!(
+            "  {} {cause}",
+            label("cause", Color::DarkGrey, stderr().is_terminal())
+        );
+    }
+    eprintln!(
+        "  {} Run `shu --help` for a command overview.",
+        label("help", Color::Cyan, stderr().is_terminal())
+    );
+}
+
+/// Return a success marker suitable for human-readable command output.
+pub fn success_marker() -> String {
+    label("✓", Color::Green, stdout().is_terminal())
+}
+
+/// Return an attention marker suitable for human-readable command output.
+pub fn warning_marker() -> String {
+    label("!", Color::Yellow, stdout().is_terminal())
+}
+
+/// Return a failure marker suitable for human-readable command output.
+pub fn failure_marker() -> String {
+    label("✗", Color::Red, stdout().is_terminal())
+}
+
+/// Add terminal color only when the output can render it correctly.
+fn label(text: &str, color: Color, color_enabled: bool) -> String {
+    if color_enabled {
+        format!("{}", text.with(color).bold())
+    } else {
+        text.to_owned()
+    }
+}

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -182,7 +182,15 @@ fn picks_a_local_repository_without_an_external_fuzzy_finder() {
 
 #[test]
 fn emits_navigation_wrappers_for_supported_shells() {
-    for shell in ["bash", "zsh", "fish", "powershell", "nushell", "posix"] {
+    for shell in [
+        "bash",
+        "zsh",
+        "fish",
+        "powershell",
+        "pwsh",
+        "nushell",
+        "posix",
+    ] {
         let output = Command::new(env!("CARGO_BIN_EXE_shu"))
             .args(["shell", "init", shell])
             .output()
@@ -196,9 +204,119 @@ fn emits_navigation_wrappers_for_supported_shells() {
     }
 }
 
+#[test]
+fn initializes_a_missing_catalog_without_blocking_everyday_commands() {
+    let fixture = Fixture::new();
+    let catalog = fixture.temp.path().join("new-library.toml");
+
+    let status = fixture.shu(["--catalog", catalog.to_str().unwrap(), "status"]);
+    status.assert_success();
+    assert!(catalog.exists(), "status should create the missing catalog");
+    let report = String::from_utf8(status.stdout).unwrap();
+    assert!(report.contains("No repositories are catalogued yet."));
+    assert!(report.contains("shu add ."));
+
+    let picked = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--path-only",
+    ]);
+    picked.assert_success();
+    assert!(picked.stdout.is_empty());
+}
+
+#[test]
+fn explains_missing_repositories_and_edits_metadata_from_a_local_clone() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_catalog("library.toml");
+
+    let duplicate = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "add",
+        fixture.seed.to_str().unwrap(),
+    ]);
+    assert!(!duplicate.status.success());
+    let duplicate_error = String::from_utf8(duplicate.stderr).unwrap();
+    assert!(duplicate_error.contains("already in the catalog"));
+    assert!(duplicate_error.contains("shu edit api --state <state> --note <text>"));
+
+    let mistaken_update = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "update",
+        fixture.seed.to_str().unwrap(),
+        "--state",
+        "active",
+    ]);
+    assert!(!mistaken_update.status.success());
+    assert!(
+        String::from_utf8(mistaken_update.stderr)
+            .unwrap()
+            .contains("shu edit")
+    );
+
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "edit",
+            fixture.seed.to_str().unwrap(),
+            "--state",
+            "parked",
+            "--note",
+            "Keep the first working prototype.",
+        ])
+        .assert_success();
+
+    let status = fixture.shu(["--catalog", catalog.to_str().unwrap(), "status"]);
+    status.assert_success();
+    let report = String::from_utf8(status.stdout).unwrap();
+    assert!(report.contains("PARKED"));
+    assert!(report.contains("missing"));
+    assert!(report.contains("Expected:"));
+    assert!(report.contains("shu ensure api"));
+    assert!(report.contains("Keep the first working prototype."));
+
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "edit",
+            "api",
+            "--clear-note",
+        ])
+        .assert_success();
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_setup_command_is_evaluable_and_forwards_to_the_binary() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_shu"));
+    let binary_directory = binary.parent().unwrap();
+    let quote = |path: &Path| path.to_string_lossy().replace('\'', "''");
+    let command = format!(
+        "$env:Path = '{};' + $env:Path; Invoke-Expression ((& '{}' shell init pwsh) -join [Environment]::NewLine); shu --version",
+        quote(binary_directory),
+        quote(&binary),
+    );
+    let output = Command::new("pwsh")
+        .args(["-NoProfile", "-Command", &command])
+        .output()
+        .unwrap();
+    output.assert_success();
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .starts_with("shu ")
+    );
+}
+
 struct Fixture {
     temp: TempDir,
     root: PathBuf,
+    seed: PathBuf,
     rewrite_prefix: String,
 }
 
@@ -230,11 +348,22 @@ impl Fixture {
         run_git(&seed, ["remote", "add", "origin"], Some(&remote));
         run_git(&seed, ["push", "-u", "origin", "main"], None);
         run_git(&remote, ["symbolic-ref", "HEAD", "refs/heads/main"], None);
+        run_git(
+            &seed,
+            [
+                "remote",
+                "set-url",
+                "origin",
+                "git@github.com:example-org/api.git",
+            ],
+            None,
+        );
 
         let rewrite_prefix = format!("file://{}/", remotes.to_string_lossy().replace('\\', "/"));
         Self {
             root: temp.path().join("library"),
             temp,
+            seed,
             rewrite_prefix,
         }
     }


### PR DESCRIPTION
Makes everyday commands create an empty catalog automatically, adds shu edit for lifecycle state and notes, clarifies missing repository status, accepts pwsh, fixes the documented PowerShell setup expression, and standardizes human diagnostics. Adds integration coverage for the reported first-run, metadata, update-mix-up, and PowerShell flows.