### PR TITLE
Add safe repository migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-27
+
+### Added
+
+- `shu add . --migrate` for previewing and atomically moving a clean local
+  Git working tree into Shu's canonical managed layout.
+
+### Security
+
+- Migration refuses dirty repositories, linked worktrees, existing targets,
+  and non-atomic cross-filesystem moves.
+
 ## [0.1.4] - 2026-07-27
 
 ### Added
@@ -90,7 +102,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/wiedymi/shu/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/wiedymi/shu/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/wiedymi/shu/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/wiedymi/shu/compare/v0.1.1...v0.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ shu restore             # Clone catalogued repositories that are missing
 shu doctor              # Check Git, the catalog, and the configured root
 shu ensure my-project   # Ensure one repository exists and print its path
 shu edit my-project --state parked --note "Paused until the next release"
+shu add . --migrate     # Move a clean local repository into ~/shu's layout
 ```
 
 To make bare `shu` open the picker, add its small shell wrapper once:
@@ -117,6 +118,19 @@ metadata without changing repository files:
 shu edit my-project --state reference --note "Useful implementation reference"
 shu edit my-project --clear-note
 ```
+
+To bring an existing clean clone into Shu's managed layout, preview the move
+first, then confirm it:
+
+```sh
+shu add . --migrate --dry-run
+shu add . --migrate
+```
+
+Migration only moves valid, clean working trees. Shu refuses repositories with
+staged, unstaged, or untracked changes; linked Git worktrees; an existing
+canonical destination; or a destination on another filesystem. It never copies
+then deletes a repository as a fallback.
 
 ## Updating
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ use crate::model::Lifecycle;
     version,
     about = "A tiny, declarative, agent-friendly repository library",
     long_about = "Shu keeps a portable catalog of Git repositories, restores missing clones into predictable paths, and lets people and agents resolve repositories reliably.",
-    after_help = "Examples:\n  shu init\n  shu add github.com/example-org/api --tag backend\n  shu restore github.com/your-account/repository-library\n  shu ensure api --path-only"
+    after_help = "Examples:\n  shu init\n  shu add github.com/example-org/api --tag backend\n  shu add . --migrate --dry-run\n  shu restore github.com/your-account/repository-library\n  shu ensure api --path-only"
 )]
 pub struct Cli {
     /// Use a specific catalog rather than the active catalog.
@@ -103,6 +103,12 @@ pub struct AddArgs {
     /// Optional human-readable context for the repository.
     #[arg(long)]
     pub note: Option<String>,
+    /// Move a clean local working tree into Shu's canonical repository layout.
+    #[arg(long)]
+    pub migrate: bool,
+    /// Preview a migration without moving files or changing the catalog.
+    #[arg(long, requires = "migrate")]
+    pub dry_run: bool,
 }
 
 /// Arguments for `shu edit`.

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -2,10 +2,12 @@
 
 use std::{
     collections::HashSet,
+    fs,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use walkdir::WalkDir;
 
 use crate::{
@@ -14,6 +16,8 @@ use crate::{
     git,
     identity::normalize_identity,
     model::{Catalog, Lifecycle, Repo},
+    paths::{absolute, root_path},
+    ui,
 };
 
 /// Initialize an empty catalog without overwriting an existing one.
@@ -40,26 +44,221 @@ pub fn init(cli: &Cli) -> Result<()> {
 /// Add an identity or the current Git repository to the active catalog.
 pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     let (path, mut catalog) = catalog::load_or_initialize(cli)?;
+    if args.migrate {
+        return migrate_and_add(cli, args, &path, &mut catalog);
+    }
     let identity = normalize_identity(&catalog::source_from_argument(&args.source)?)?;
-    if let Some(existing) = catalog
-        .repos
-        .iter()
-        .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(&identity))
-    {
+    if let Some(existing) = existing_repo(&catalog, &identity) {
         bail!(
             "{identity} is already in the catalog. To change its state or note, run `shu edit {} --state <state> --note <text>`",
             catalog::repo_name(existing)
         );
     }
+    add_entry(&mut catalog, args, &identity);
+    catalog::save(&path, &catalog)?;
+    println!("Added {identity}");
+    Ok(())
+}
+
+/// Move a clean local working tree to its canonical Shu path, then catalog it.
+fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog) -> Result<()> {
+    let source = migration_source(&args.source)?;
+    let remote = git::output(&source, ["remote", "get-url", "origin"])?;
+    let identity = normalize_identity(&remote)?;
+    let destination = absolute(&root_path(catalog)?.join(&identity))?;
+    let existing = existing_repo(catalog, &identity).is_some();
+
+    println!("Migrate repository\n");
+    println!("  Identity: {identity}");
+    println!("  From:     {}", source.display());
+    println!("  To:       {}", destination.display());
+
+    if source == destination {
+        println!("  {} Already at Shu's canonical path", ui::success_marker());
+        if args.dry_run {
+            println!("\nDry run: no files or catalog entries were changed.");
+            return Ok(());
+        }
+        return finish_catalog_add(path, catalog, args, &identity, existing, false);
+    }
+    if destination.starts_with(&source) {
+        bail!(
+            "canonical destination {} is inside the source repository {}; choose a repository root outside the source before migrating",
+            destination.display(),
+            source.display()
+        );
+    }
+    if destination.exists() {
+        bail!(
+            "canonical destination already exists: {}. Shu will not overwrite an existing directory",
+            destination.display()
+        );
+    }
+    if !git::is_clean(&source)? {
+        bail!(
+            "working tree has staged, unstaged, or untracked changes: {}. Commit, stash, or remove the changes before migrating",
+            source.display()
+        );
+    }
+    println!("  {} Working tree is clean", ui::success_marker());
+    if git::has_linked_worktrees(&source)? {
+        bail!(
+            "repository has linked Git worktrees. Shu will not move it because those worktrees may reference the current path"
+        );
+    }
+    println!("  {} No linked worktrees", ui::success_marker());
+
+    if args.dry_run {
+        println!("\nDry run: no files or catalog entries were changed.");
+        return Ok(());
+    }
+    if !confirm_migration(cli)? {
+        println!("No changes made.");
+        return Ok(());
+    }
+    if !same_filesystem(&source, &destination)? {
+        bail!(
+            "source and canonical destination are on different filesystems. Shu only performs atomic moves; choose a root on the same filesystem or move the repository manually"
+        );
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow!("canonical destination has no parent directory"))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "could not create destination directory {}",
+            parent.display()
+        )
+    })?;
+    fs::rename(&source, &destination).with_context(|| {
+        format!(
+            "could not move {} to {}. Shu only performs atomic moves on the same filesystem; no repository files were copied or deleted",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    println!("  {} Moved repository", ui::success_marker());
+    finish_catalog_add(path, catalog, args, &identity, existing, true)
+}
+
+/// Return whether the source and destination reside on a filesystem that supports rename.
+fn same_filesystem(source: &Path, destination: &Path) -> Result<bool> {
+    let destination_parent = destination
+        .parent()
+        .ok_or_else(|| anyhow!("canonical destination has no parent directory"))?;
+    let existing_destination = destination_parent
+        .ancestors()
+        .find(|path| path.exists())
+        .ok_or_else(|| anyhow!("canonical destination has no existing ancestor"))?;
+    let existing_destination = fs::canonicalize(existing_destination).with_context(|| {
+        format!(
+            "could not resolve destination filesystem root {}",
+            existing_destination.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(fs::metadata(source)?.dev() == fs::metadata(existing_destination)?.dev())
+    }
+    #[cfg(windows)]
+    {
+        let source_volume = volume_prefix(source)?;
+        let destination_volume = volume_prefix(&existing_destination)?;
+        Ok(source_volume.eq_ignore_ascii_case(&destination_volume))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (source, existing_destination);
+        Ok(true)
+    }
+}
+
+/// Return a Windows drive or UNC prefix for comparing filesystem roots.
+#[cfg(windows)]
+fn volume_prefix(path: &Path) -> Result<String> {
+    use std::path::Component;
+
+    match path.components().next() {
+        Some(Component::Prefix(prefix)) => Ok(prefix
+            .as_os_str()
+            .to_string_lossy()
+            .trim_start_matches(r"\\?\")
+            .to_string()),
+        _ => bail!("could not determine filesystem root for {}", path.display()),
+    }
+}
+
+/// Resolve `.` or an existing path to the root of a local Git working tree.
+fn migration_source(value: &str) -> Result<PathBuf> {
+    let requested = if value == "." {
+        std::env::current_dir()?
+    } else {
+        PathBuf::from(value)
+    };
+    if !requested.exists() {
+        bail!("--migrate requires `.` or an existing local Git working tree, not {value}");
+    }
+    git::worktree_root(&requested)
+}
+
+/// Ask for explicit approval before a filesystem-moving migration.
+fn confirm_migration(cli: &Cli) -> Result<bool> {
+    if cli.yes {
+        return Ok(true);
+    }
+    if cli.non_interactive {
+        bail!("migration needs confirmation; rerun with --yes to approve it non-interactively");
+    }
+    eprint!("\nMove this repository into Shu's managed library? [y/N] ");
+    io::stderr().flush()?;
+    let mut response = String::new();
+    io::stdin().read_line(&mut response)?;
+    Ok(response.trim().eq_ignore_ascii_case("y") || response.trim().eq_ignore_ascii_case("yes"))
+}
+
+/// Finish catalog changes after migration or after confirming a canonical location.
+fn finish_catalog_add(
+    path: &Path,
+    catalog: &mut Catalog,
+    args: &AddArgs,
+    identity: &str,
+    existing: bool,
+    moved: bool,
+) -> Result<()> {
+    if existing {
+        println!(
+            "  {} Preserved existing catalog metadata",
+            ui::success_marker()
+        );
+    } else {
+        add_entry(catalog, args, identity);
+        catalog::save(path, catalog)?;
+        println!("  {} Added to catalog", ui::success_marker());
+    }
+    if moved {
+        println!("\nMigrated {identity} into Shu's managed library.");
+    }
+    Ok(())
+}
+
+/// Return an existing catalog entry for one normalized identity, when present.
+fn existing_repo<'a>(catalog: &'a Catalog, identity: &str) -> Option<&'a Repo> {
+    catalog
+        .repos
+        .iter()
+        .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
+}
+
+/// Add one catalog entry using the metadata supplied to `shu add`.
+fn add_entry(catalog: &mut Catalog, args: &AddArgs, identity: &str) {
     catalog.repos.push(Repo {
-        source: identity.clone(),
+        source: identity.to_owned(),
         state: args.state,
         tags: catalog::unique(args.tag.clone()),
         note: args.note.clone(),
     });
-    catalog::save(&path, &catalog)?;
-    println!("Added {identity}");
-    Ok(())
 }
 
 /// Change the explicit lifecycle state or note for an existing catalog entry.

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,7 +5,7 @@
 
 use std::{
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -14,7 +14,31 @@ use anyhow::{Context, Result, anyhow, bail};
 
 /// Return whether a path is an accessible Git working tree.
 pub fn is_repo(path: &Path) -> bool {
-    output(path, ["rev-parse", "--is-inside-work-tree"]).is_ok()
+    output(path, ["rev-parse", "--is-inside-work-tree"]).is_ok_and(|value| value == "true")
+}
+
+/// Resolve a local path inside a Git working tree to its top-level directory.
+pub fn worktree_root(path: &Path) -> Result<PathBuf> {
+    if !is_repo(path) {
+        bail!("not a Git working tree: {}", path.display());
+    }
+    let root = PathBuf::from(output(path, ["rev-parse", "--show-toplevel"])?);
+    fs::canonicalize(&root)
+        .with_context(|| format!("could not resolve Git working tree {}", root.display()))
+}
+
+/// Return whether a working tree has no staged, unstaged, or untracked changes.
+pub fn is_clean(path: &Path) -> Result<bool> {
+    Ok(output(path, ["status", "--porcelain=v1", "--untracked-files=all"])?.is_empty())
+}
+
+/// Return whether Git reports another linked working tree for this repository.
+pub fn has_linked_worktrees(path: &Path) -> Result<bool> {
+    let count = output(path, ["worktree", "list", "--porcelain"])?
+        .lines()
+        .filter(|line| line.starts_with("worktree "))
+        .count();
+    Ok(count > 1)
 }
 
 /// Run Git in a working directory and return trimmed standard output on success.

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -290,6 +290,147 @@ fn explains_missing_repositories_and_edits_metadata_from_a_local_clone() {
         .assert_success();
 }
 
+#[test]
+fn migrates_a_clean_repository_into_shus_canonical_layout() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_empty_catalog("library.toml");
+    let expected = fixture
+        .root
+        .join("github.com")
+        .join("example-org")
+        .join("api");
+
+    let preview = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "add",
+        fixture.seed.to_str().unwrap(),
+        "--migrate",
+        "--dry-run",
+    ]);
+    preview.assert_success();
+    assert!(
+        fixture.seed.exists(),
+        "dry runs must not move the repository"
+    );
+    assert!(!expected.exists(), "dry runs must not create a destination");
+    assert!(
+        String::from_utf8(preview.stdout)
+            .unwrap()
+            .contains("Dry run: no files or catalog entries were changed.")
+    );
+
+    let migrated = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "--yes",
+        "add",
+        fixture.seed.to_str().unwrap(),
+        "--migrate",
+    ]);
+    migrated.assert_success();
+    assert!(
+        !fixture.seed.exists(),
+        "migration should move the source directory"
+    );
+    assert!(expected.join(".git").exists());
+    let output = String::from_utf8(migrated.stdout).unwrap();
+    assert!(output.contains("Working tree is clean"));
+    assert!(output.contains("Moved repository"));
+    assert!(output.contains("Added to catalog"));
+
+    let status = fixture.shu(["--catalog", catalog.to_str().unwrap(), "status"]);
+    status.assert_success();
+    assert!(
+        String::from_utf8(status.stdout)
+            .unwrap()
+            .contains("present")
+    );
+}
+
+#[test]
+fn migrates_an_already_catalogued_repository_without_overwriting_metadata() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_catalog("library.toml");
+    let expected = fixture
+        .root
+        .join("github.com")
+        .join("example-org")
+        .join("api");
+
+    let migrated = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "--yes",
+        "add",
+        fixture.seed.to_str().unwrap(),
+        "--migrate",
+    ]);
+    migrated.assert_success();
+    assert!(!fixture.seed.exists());
+    assert!(expected.join(".git").exists());
+    assert!(
+        String::from_utf8(migrated.stdout)
+            .unwrap()
+            .contains("Preserved existing catalog metadata")
+    );
+}
+
+#[test]
+fn refuses_to_migrate_a_repository_with_uncommitted_changes() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_empty_catalog("library.toml");
+    fs::write(fixture.seed.join("uncommitted.txt"), "do not move\n").unwrap();
+
+    let migrated = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "--yes",
+        "add",
+        fixture.seed.to_str().unwrap(),
+        "--migrate",
+    ]);
+    assert!(!migrated.status.success());
+    assert!(fixture.seed.exists(), "dirty sources must stay in place");
+    assert!(
+        String::from_utf8(migrated.stderr)
+            .unwrap()
+            .contains("working tree has staged, unstaged, or untracked changes")
+    );
+}
+
+#[test]
+fn refuses_to_migrate_a_repository_with_linked_worktrees() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_empty_catalog("library.toml");
+    let linked_worktree = fixture.temp.path().join("linked-worktree");
+    run_git(
+        &fixture.seed,
+        ["worktree", "add", "--detach"],
+        Some(&linked_worktree),
+    );
+
+    let migrated = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "--yes",
+        "add",
+        fixture.seed.to_str().unwrap(),
+        "--migrate",
+    ]);
+
+    assert!(!migrated.status.success());
+    assert!(
+        fixture.seed.exists(),
+        "linked working trees must stay in place"
+    );
+    assert!(
+        String::from_utf8(migrated.stderr)
+            .unwrap()
+            .contains("repository has linked Git worktrees")
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn powershell_setup_command_is_evaluable_and_forwards_to_the_binary() {
@@ -372,6 +513,13 @@ impl Fixture {
         let path = self.temp.path().join(name);
         let root = self.root.to_string_lossy().replace('\\', "/");
         fs::write(&path, format!("version = 1\nroot = \"{root}\"\n\n[[repos]]\nsource = \"{IDENTITY}\"\nstate = \"active\"\ntags = [\"integration\"]\n")).unwrap();
+        path
+    }
+
+    fn write_empty_catalog(&self, name: &str) -> PathBuf {
+        let path = self.temp.path().join(name);
+        let root = self.root.to_string_lossy().replace('\\', "/");
+        fs::write(&path, format!("version = 1\nroot = \"{root}\"\n")).unwrap();
         path
     }
 

--- a/tests/docker/e2e.sh
+++ b/tests/docker/e2e.sh
@@ -36,6 +36,12 @@ shu --catalog "$workspace/shu.toml" doctor | grep -q '^✓ catalog:'
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$path"
 shu --catalog "$workspace/shu.toml" --json list | grep -q '"observed_state": "present"'
 
+# Migration moves a clean working tree atomically into Shu's canonical layout.
+git -C "$workspace/seed" remote set-url origin 'git@github.com:example-org/migrated.git'
+shu --catalog "$workspace/shu.toml" --yes add "$workspace/seed" --migrate
+test ! -d "$workspace/seed"
+test -d "$workspace/library/github.com/example-org/migrated/.git"
+
 # Exercise the release installer against a locally generated, checksummed
 # release payload. The fake curl command gives the installer the same
 # command-line contract it has when downloading a GitHub Release.


### PR DESCRIPTION
## What changed\n\n- Adds shu add . --migrate to move a clean local working tree into Shu’s canonical managed layout.\n- Adds a non-destructive --dry-run preview and explicit confirmation; automation must pass --yes.\n- Preserves existing catalog metadata when a known repository is moved into its missing canonical location.\n- Adds Windows integration coverage and a Linux Docker end-to-end migration flow.\n\n## Safety\n\nMigration refuses dirty repositories, linked Git worktrees, existing destinations, and different filesystems. It only uses an atomic rename and never falls back to copy-then-delete.\n\n## Validation\n\n- cargo fmt\n- cargo test\n- cargo clippy --all-targets -- -D warnings\n- cargo doc --no-deps\n- release build\n- Docker end-to-end test\n