### PR TITLE
Support multiple repository clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,31 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-07-27
+
+### Added
+
+- Multiple local clone paths and an explicit preferred clone are now stored
+  directly in each repository entry's `paths` and `primary` fields in the one
+  `shu.toml` file.
+- `shu locations <repository>` shows all recorded clones and dynamically
+  discovered real Git worktrees. `--primary <path>` selects the clone used by
+  `shu path`, `shu ensure`, and the first picker result.
+- The picker now includes linked Git worktrees without storing them in TOML.
+
+### Changed
+
+- `shu add .` appends the current clone to its catalog entry instead of
+  replacing a previously recorded clone. `shu add . --migrate` replaces the
+  moved path and makes the managed destination primary.
+
 ## [0.1.8] - 2026-07-27
 
 ### Changed
 
-- `shu add .` now records an existing clone as machine-local observation state
-  instead of treating the canonical Shu path as its only location. The
-  portable catalog stays path-free, and `--migrate` remains the explicit move.
+- `shu add .` records an existing clone instead of treating the canonical Shu
+  path as its only location. This was superseded by the one-file `paths` model
+  in 0.1.9.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Checks](https://img.shields.io/github/actions/workflow/status/wiedymi/shu/ci.yml?branch=main&style=flat-square&label=checks)](https://github.com/wiedymi/shu/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/wiedymi/shu?style=flat-square)](LICENSE)
 
-**Your portable library of Git repositories.**
+**Your simple library of Git repositories.**
 
-Shu keeps a small, readable catalog of the repositories you care about. Put the
-catalog in Git, restore it on a new computer, and always know where a project
-lives locally.
+Shu keeps one small, readable `shu.toml` catalog of the repositories you care
+about. Put it in Git, restore it on a new computer, and always know where a
+project lives locally.
 
 - Restore your repository collection with one command.
 - Keep old projects as active, parked, reference, or archived—without deleting them.
@@ -35,11 +35,10 @@ shu restore github.com/your-name/your-repository-library
 
 Shu reads the repository's root-level `shu.toml`, puts missing repositories
 under `~/shu` by default, and leaves existing repositories alone. `shu add .`
-also remembers that current clone on this machine, so it remains available to
-`shu`, `shu path`, and `shu ensure` without an unnecessary move. If you start
-with an empty machine, everyday commands create an empty local catalog for you.
-Those remembered paths live in Shu's local state, never in the portable
-`shu.toml` you commit or restore elsewhere.
+adds that current clone to the repository's `paths` list in the same catalog,
+so it remains available to `shu`, `shu path`, and `shu ensure` without an
+unnecessary move. If you start with an empty machine, everyday commands create
+an empty local catalog for you.
 
 ## Install
 
@@ -72,6 +71,7 @@ shu status              # See what is present, missing, or uncatalogued
 shu restore             # Clone catalogued repositories that are missing
 shu doctor              # Check Git, the catalog, and the configured root
 shu ensure my-project   # Ensure one repository exists and print its path
+shu locations my-project # Show every known clone and its Git worktrees
 shu edit my-project --state parked --note "Paused until the next release"
 shu add . --migrate     # Move a clean local repository into ~/shu's layout
 ```
@@ -94,7 +94,8 @@ manage the wrapper yourself, use `shu shell init pwsh --print` or provide an
 explicit target with `shu shell init pwsh --path ./profile.ps1`.
 
 The picker offers repositories that are actually present on this machine,
-including existing clones recorded with `shu add .`. `--migrate` remains the
+including every existing clone recorded with `shu add .` and real Git
+worktrees discovered dynamically from those clones. `--migrate` remains the
 explicit option to move a clean clone into Shu's managed root. If `shu status`
 shows a repository as **missing**, restore it with `shu ensure name` or run
 `shu add .` from the existing clone to record it.
@@ -105,7 +106,12 @@ For scripts and agents:
 repo_path="$(shu ensure github.com/example-org/project --path-only)"
 ```
 
-## A small catalog
+## `shu.toml` reference
+
+`shu.toml` is Shu's only user-facing configuration file. It describes the
+repositories you care about and, when you add existing clones, the local paths
+where you keep them. There is one `[[repos]]` entry for each repository
+identity.
 
 ```toml
 version = 1
@@ -116,6 +122,58 @@ source = "github.com/your-name/project"
 state = "active"
 tags = ["personal", "rust"]
 note = "A project I work on regularly"
+paths = [
+  "C:/Users/you/Projects/project",
+  "C:/Users/you/shu/github.com/your-name/project",
+]
+primary = "C:/Users/you/Projects/project"
+```
+
+| Field | Meaning | Default |
+| --- | --- | --- |
+| `version` | Catalog format version. | Required; currently `1`. |
+| `root` | Canonical destination used by `shu restore` and `shu ensure` for a repository that has no usable local clone. | `~/shu` |
+| `repos[].source` | Repository identity: `host/namespace/repository`. HTTPS and SSH URLs are normalized to this form by `shu add`. | Required. |
+| `repos[].state` | Your lifecycle label: `active`, `parked`, `reference`, or `archived`. It is never inferred from age. | `active` |
+| `repos[].tags` | Optional labels for filtering and grouping. | `[]` |
+| `repos[].note` | Optional human context about why the repository is kept. | Absent |
+| `repos[].paths` | Every known full clone of the repository. `shu add .` appends the current clone without moving it. | `[]` |
+| `repos[].primary` | The clone Shu prefers for `shu path`, `shu ensure`, and the first picker result. | The first valid path, then the managed path. |
+
+`paths` holds normal full-clone roots. A path that does not exist on the
+current computer is ignored safely, which makes one catalog usable across your
+machines. Git worktrees are deliberately not stored: Shu discovers them from
+each valid clone every time it opens the picker or runs `shu locations`.
+
+`root` does not move anything by itself. It only determines the canonical
+managed destination:
+
+```text
+<root>/<host>/<namespace>/<repository>
+```
+
+For example, `github.com/your-name/project` with the default root belongs at:
+
+```text
+~/shu/github.com/your-name/project
+```
+
+Choose the preferred clone explicitly with:
+
+```sh
+shu locations project --primary /path/to/project
+```
+
+Inspect all known clones and dynamically discovered worktrees with:
+
+```sh
+shu locations project
+```
+
+To register another existing full clone, run this from inside it:
+
+```sh
+shu add .
 ```
 
 The catalog is deliberately data-only: no secrets, setup hooks, or arbitrary

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,14 +1,10 @@
 //! Persistent catalog access, repository lookup, and application-state paths.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
 };
-
-use anyhow::{Context, Result, anyhow, bail};
-use directories::ProjectDirs;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     cli::{Cli, FilterArgs},
@@ -16,6 +12,8 @@ use crate::{
     identity::normalize_identity,
     model::{Catalog, Repo},
 };
+use anyhow::{Context, Result, anyhow, bail};
+use directories::ProjectDirs;
 
 /// Return the active catalog path, honoring the global `--catalog` override.
 pub fn catalog_path(cli: &Cli) -> Result<PathBuf> {
@@ -40,95 +38,6 @@ pub fn state_dir() -> Result<PathBuf> {
         .state_dir()
         .unwrap_or_else(|| project.data_local_dir())
         .to_path_buf())
-}
-
-/// Return the machine-local repository-location sidecar for this catalog.
-///
-/// A custom catalog receives a sibling sidecar so test catalogs and portable
-/// catalogs do not write into the user's normal Shu state directory.
-pub fn local_state_path(cli: &Cli) -> Result<PathBuf> {
-    if let Some(catalog) = &cli.catalog {
-        return Ok(catalog.with_extension("local.json"));
-    }
-    Ok(state_dir()?.join("repositories.json"))
-}
-
-/// Look up a repository path observed on this machine, if one is recorded.
-pub fn remembered_local_path(cli: &Cli, identity: &str) -> Result<Option<PathBuf>> {
-    let identity = normalize_identity(identity)?;
-    Ok(load_local_state(cli)?
-        .repositories
-        .get(&identity)
-        .map(PathBuf::from))
-}
-
-/// Remember an existing local clone without adding machine-specific paths to
-/// the portable catalog.
-pub fn remember_local_path(cli: &Cli, identity: &str, path: &Path) -> Result<()> {
-    let identity = normalize_identity(identity)?;
-    let path = crate::paths::absolute(path)?;
-    let mut state = load_local_state(cli)?;
-    state
-        .repositories
-        .insert(identity, path.display().to_string());
-    save_local_state(cli, &state)
-}
-
-/// Machine-local observations that are deliberately kept out of `shu.toml`.
-#[derive(Debug, Deserialize, Serialize)]
-struct LocalState {
-    /// Format version for forward-compatible local cache changes.
-    #[serde(default = "local_state_version")]
-    version: u32,
-    /// Last known working-tree path for each normalized repository identity.
-    #[serde(default)]
-    repositories: BTreeMap<String, String>,
-}
-
-impl Default for LocalState {
-    fn default() -> Self {
-        Self {
-            version: local_state_version(),
-            repositories: BTreeMap::new(),
-        }
-    }
-}
-
-/// Return the current local-state format version.
-const fn local_state_version() -> u32 {
-    1
-}
-
-/// Read the local observation sidecar, treating an absent file as empty state.
-fn load_local_state(cli: &Cli) -> Result<LocalState> {
-    let path = local_state_path(cli)?;
-    let data = match fs::read(&path) {
-        Ok(data) => data,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(LocalState::default());
-        }
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("could not read local state {}", path.display()));
-        }
-    };
-    let state: LocalState = serde_json::from_slice(&data)
-        .with_context(|| format!("invalid local state {}", path.display()))?;
-    if state.version != local_state_version() {
-        bail!("unsupported local state version {}", state.version);
-    }
-    Ok(state)
-}
-
-/// Persist machine-local observations beside the selected catalog or state directory.
-fn save_local_state(cli: &Cli, state: &LocalState) -> Result<()> {
-    let path = local_state_path(cli)?;
-    let parent = path
-        .parent()
-        .ok_or_else(|| anyhow!("local state path has no parent directory"))?;
-    fs::create_dir_all(parent)?;
-    fs::write(&path, serde_json::to_vec_pretty(state)?)
-        .with_context(|| format!("could not write local state {}", path.display()))
 }
 
 /// Load and validate the selected catalog, returning its path and parsed data.
@@ -280,12 +189,16 @@ mod tests {
                     state: Lifecycle::Active,
                     tags: vec![],
                     note: None,
+                    paths: vec![],
+                    primary: None,
                 },
                 Repo {
                     source: "github.com/acme/api".into(),
                     state: Lifecycle::Parked,
                     tags: vec![],
                     note: None,
+                    paths: vec![],
+                    primary: None,
                 },
             ],
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,8 +12,8 @@ use crate::model::Lifecycle;
     name = "shu",
     version,
     about = "A tiny, declarative, agent-friendly repository library",
-    long_about = "Shu keeps a portable catalog of Git repositories, restores missing clones into predictable paths, and lets people and agents resolve repositories reliably.",
-    after_help = "Examples:\n  shu init\n  shu add github.com/example-org/api --tag backend\n  shu add . --migrate --dry-run\n  shu restore github.com/your-account/repository-library\n  shu ensure api --path-only"
+    long_about = "Shu keeps one readable catalog of Git repositories, restores missing clones into predictable paths, and lets people and agents resolve repositories reliably.",
+    after_help = "Examples:\n  shu init\n  shu add github.com/example-org/api --tag backend\n  shu add . --migrate --dry-run\n  shu locations api\n  shu restore github.com/your-account/repository-library\n  shu ensure api --path-only"
 )]
 pub struct Cli {
     /// Use a specific catalog rather than the active catalog.
@@ -74,6 +74,8 @@ pub enum Commands {
     Ensure(EnsureArgs),
     /// Print the local path of an existing catalogued repository.
     Path(SelectorArgs),
+    /// Show known local clone paths or choose the preferred clone for a repository.
+    Locations(LocationsArgs),
     /// List catalogued repositories with optional filters.
     List(ListArgs),
     /// Change only a repository's declared lifecycle state.
@@ -93,8 +95,8 @@ pub enum Commands {
 pub struct AddArgs {
     /// A normalized repository identity, Git URL, or `.` for the current repository.
     ///
-    /// Local clones are remembered on this machine without moving them; add
-    /// `--migrate` to move a clean clone into Shu's managed root.
+    /// Local clones are recorded in the repository's `paths` list without
+    /// moving them; add `--migrate` to move a clean clone into Shu's managed root.
     #[arg(value_name = "REPOSITORY")]
     pub source: String,
     /// Lifecycle state to record in the catalog.
@@ -214,6 +216,16 @@ pub struct EnsureArgs {
 pub struct SelectorArgs {
     /// Full identity, unique suffix, or unique repository name.
     pub selector: String,
+}
+
+/// Arguments for `shu locations`.
+#[derive(Args)]
+pub struct LocationsArgs {
+    /// Full identity, unique suffix, or unique repository name.
+    pub selector: String,
+    /// Make one already known local clone the preferred path for this repository.
+    #[arg(long, value_name = "PATH")]
+    pub primary: Option<PathBuf>,
 }
 
 /// Arguments for `shu list`.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,4 +14,4 @@ pub use pick::pick;
 pub use restore::{ensure, path_command, restore, update};
 pub use shell::shell;
 pub use upgrade::upgrade;
-pub use view::{list, status};
+pub use view::{list, locations_command, status};

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -49,23 +49,32 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     }
     let identity = normalize_identity(&catalog::source_from_argument(&args.source)?)?;
     let local_path = local_source_path(&args.source)?;
-    if let Some(existing) = existing_repo(&catalog, &identity) {
+    if let Some(index) = existing_repo_index(&catalog, &identity) {
         if let Some(local_path) = local_path {
-            catalog::remember_local_path(cli, &identity, &local_path)?;
-            println!("Already catalogued {}", catalog::repo_name(existing));
+            let repo = &mut catalog.repos[index];
+            remember_path(repo, &local_path)?;
+            let name = catalog::repo_name(repo).to_owned();
+            catalog::save(&path, &catalog)?;
+            println!("Already catalogued {name}");
             println!("  Local clone: {}", local_path.display());
             return Ok(());
         }
+        let existing = &catalog.repos[index];
         bail!(
             "{identity} is already in the catalog. To change its state or note, run `shu edit {} --state <state> --note <text>`",
             catalog::repo_name(existing)
         );
     }
     add_entry(&mut catalog, args, &identity);
+    if let Some(local_path) = &local_path {
+        remember_path(
+            catalog.repos.last_mut().expect("entry was just added"),
+            local_path,
+        )?;
+    }
     catalog::save(&path, &catalog)?;
     println!("Added {identity}");
     if let Some(local_path) = local_path {
-        catalog::remember_local_path(cli, &identity, &local_path)?;
         println!("  Local clone: {}", local_path.display());
     }
     Ok(())
@@ -91,7 +100,8 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
             return Ok(());
         }
         finish_catalog_add(path, catalog, args, &identity, existing, false)?;
-        catalog::remember_local_path(cli, &identity, &destination)?;
+        replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
+        catalog::save(path, catalog)?;
         return Ok(());
     }
     if destination.starts_with(&source) {
@@ -152,7 +162,8 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
     })?;
     println!("  {} Moved repository", ui::success_marker());
     finish_catalog_add(path, catalog, args, &identity, existing, true)?;
-    catalog::remember_local_path(cli, &identity, &destination)
+    replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
+    catalog::save(path, catalog)
 }
 
 /// Return whether the source and destination reside on a filesystem that supports rename.
@@ -219,9 +230,9 @@ fn migration_source(value: &str) -> Result<PathBuf> {
 
 /// Return a working-tree root when an add argument refers to a local clone.
 ///
-/// A normal `shu add .` records this path in machine-local state. The portable
-/// catalog only keeps repository identity, leaving `--migrate` as the explicit
-/// operation that moves a clone into Shu's managed root.
+/// A normal `shu add .` records this path in the repository's `paths` list in
+/// `shu.toml`. `--migrate` remains the explicit operation that moves a clone
+/// into Shu's managed root.
 fn local_source_path(value: &str) -> Result<Option<PathBuf>> {
     if value == "." || Path::new(value).exists() {
         return git::worktree_root(&if value == "." {
@@ -282,6 +293,23 @@ fn existing_repo<'a>(catalog: &'a Catalog, identity: &str) -> Option<&'a Repo> {
         .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
 }
 
+/// Return the index of an existing entry for one normalized identity.
+fn existing_repo_index(catalog: &Catalog, identity: &str) -> Option<usize> {
+    catalog
+        .repos
+        .iter()
+        .position(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
+}
+
+/// Return the mutable catalog entry for an identity that was just ensured to exist.
+fn catalog_repo_mut<'a>(catalog: &'a mut Catalog, identity: &str) -> Result<&'a mut Repo> {
+    catalog
+        .repos
+        .iter_mut()
+        .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
+        .ok_or_else(|| anyhow!("catalog entry disappeared for {identity}"))
+}
+
 /// Add one catalog entry using the metadata supplied to `shu add`.
 fn add_entry(catalog: &mut Catalog, args: &AddArgs, identity: &str) {
     catalog.repos.push(Repo {
@@ -289,7 +317,28 @@ fn add_entry(catalog: &mut Catalog, args: &AddArgs, identity: &str) {
         state: args.state,
         tags: catalog::unique(args.tag.clone()),
         note: args.note.clone(),
+        paths: vec![],
+        primary: None,
     });
+}
+
+/// Remember a clone path and choose it only when the current primary is invalid.
+fn remember_path(repo: &mut Repo, path: &Path) -> Result<()> {
+    let path = absolute(path)?;
+    let replace_primary = repo
+        .primary_path()
+        .is_none_or(|primary| !git::is_repo(&primary));
+    repo.add_path(path.clone());
+    if replace_primary {
+        repo.primary = Some(path.display().to_string());
+    }
+    Ok(())
+}
+
+/// Replace a moved source path with its canonical destination and prefer it.
+fn replace_path(repo: &mut Repo, source: &Path, destination: &Path) -> Result<()> {
+    repo.replace_path(&absolute(source)?, absolute(destination)?);
+    Ok(())
 }
 
 /// Change the explicit lifecycle state or note for an existing catalog entry.
@@ -414,10 +463,13 @@ fn import_discovered(cli: &Cli, found: &[(PathBuf, String)]) -> Result<()> {
                 state: Lifecycle::Active,
                 tags: vec![],
                 note: None,
+                paths: vec![],
+                primary: None,
             });
             added += 1;
         }
-        catalog::remember_local_path(cli, identity, local_path)?;
+        let repo = catalog_repo_mut(&mut catalog, identity)?;
+        remember_path(repo, local_path)?;
     }
     catalog::save(&path, &catalog)?;
     println!("Added {added} repository entries to {}", path.display());

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -27,8 +27,11 @@ const MAX_VISIBLE_RESULTS: usize = 12;
 pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
     let (_, catalog) = catalog::load_or_initialize(cli)?;
     let candidates = catalog::filtered(&catalog, &args.filter)
-        .filter_map(|repo| candidate(cli, &catalog, repo).transpose())
-        .collect::<Result<Vec<_>>>()?;
+        .map(|repo| candidates(&catalog, repo))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
     if candidates.is_empty() {
         bail!(
             "no catalogued repositories are available locally. Run `shu status` to see expected or recorded paths; use `shu ensure <repository>` to clone one, or run `shu add .` from an existing clone to record it"
@@ -59,25 +62,21 @@ pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
 struct Candidate {
     identity: String,
     state: String,
-    tags: String,
     path: PathBuf,
 }
 
-/// Convert a valid local catalog entry into a searchable picker candidate.
-fn candidate(cli: &Cli, catalog: &crate::model::Catalog, repo: &Repo) -> Result<Option<Candidate>> {
-    let Some(path) = locations::present_path(cli, catalog, repo)? else {
-        return Ok(None);
-    };
-    Ok(Some(Candidate {
-        identity: repo.source.clone(),
-        state: repo.state.to_string(),
-        tags: if repo.tags.is_empty() {
-            "-".into()
-        } else {
-            repo.tags.join(",")
-        },
-        path,
-    }))
+/// Convert each present clone and Git worktree into a searchable picker candidate.
+fn candidates(catalog: &crate::model::Catalog, repo: &Repo) -> Result<Vec<Candidate>> {
+    locations::pickable_paths(catalog, repo).map(|paths| {
+        paths
+            .into_iter()
+            .map(|path| Candidate {
+                identity: repo.source.clone(),
+                state: repo.state.to_string(),
+                path,
+            })
+            .collect()
+    })
 }
 
 /// Run a raw-key terminal interface until the user selects a candidate or cancels.
@@ -143,10 +142,16 @@ fn ranked(candidates: &[Candidate], query: &str) -> Vec<Candidate> {
     let mut matches = candidates
         .iter()
         .filter_map(|candidate| {
-            fuzzy_score(&candidate.identity, query).map(|score| (score, candidate.clone()))
+            fuzzy_score(
+                &format!("{} {}", candidate.identity, candidate.path.display()),
+                query,
+            )
+            .map(|score| (score, candidate.clone()))
         })
         .collect::<Vec<_>>();
-    matches.sort_by_key(|(score, candidate)| (Reverse(*score), candidate.identity.clone()));
+    // `sort_by_key` is stable, so equal fuzzy scores retain the primary-first
+    // order supplied by `locations::pickable_paths`.
+    matches.sort_by_key(|(score, _)| Reverse(*score));
     matches
         .into_iter()
         .map(|(_, candidate)| candidate)
@@ -222,7 +227,9 @@ impl PickerTerminal {
             writeln!(
                 self.stderr,
                 "{marker} {:<36} {:<10} {}",
-                candidate.identity, candidate.state, candidate.tags
+                candidate.identity,
+                candidate.state,
+                candidate.path.display()
             )?;
         }
         self.stderr.flush()?;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -22,19 +22,40 @@ pub fn restore(cli: &Cli, args: &RestoreArgs) -> Result<()> {
     if let Some(source) = &args.source {
         activate_source(cli, args, source)?;
     }
-    let (_, catalog) = catalog::load_or_initialize(cli)?;
-    let repos = catalog::filtered(&catalog, &args.filter).collect::<Vec<_>>();
-    if !confirm_restore(cli, args, repos.len())? {
+    let (catalog_path, mut catalog) = catalog::load_or_initialize(cli)?;
+    let repo_indices = catalog
+        .repos
+        .iter()
+        .enumerate()
+        .filter(|(_, repo)| {
+            args.filter.state.is_none_or(|state| repo.state == state)
+                && args
+                    .filter
+                    .tag
+                    .as_ref()
+                    .is_none_or(|tag| repo.tags.contains(tag))
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if !confirm_restore(cli, args, repo_indices.len())? {
         println!("No changes made.");
         return Ok(());
     }
     fs::create_dir_all(root_path(&catalog)?)?;
     let mut failures = 0;
-    for repo in repos {
-        if let Err(error) = restore_one(cli, &catalog, repo) {
-            eprintln!("! {}: {error:#}", repo.source);
-            failures += 1;
+    let mut changed = false;
+    for index in repo_indices {
+        let source = catalog.repos[index].source.clone();
+        match restore_one(&mut catalog, index) {
+            Ok(wrote_path) => changed |= wrote_path,
+            Err(error) => {
+                eprintln!("! {source}: {error:#}");
+                failures += 1;
+            }
         }
+    }
+    if changed {
+        catalog::save(&catalog_path, &catalog)?;
     }
     if failures > 0 {
         bail!(
@@ -69,9 +90,10 @@ pub fn update(cli: &Cli, args: &UpdateArgs) -> Result<()> {
 
 /// Ensure one selected repository exists and print its absolute local path.
 pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
-    let (_, catalog) = catalog::load_or_initialize(cli)?;
-    let repo = catalog::select(&catalog, &args.selector)?;
-    if let Some(existing) = locations::present_path(cli, &catalog, repo)? {
+    let (catalog_path, mut catalog) = catalog::load_or_initialize(cli)?;
+    let index = catalog::select_index(&catalog, &args.selector)?;
+    let repo = &catalog.repos[index];
+    if let Some(existing) = locations::present_path(&catalog, repo)? {
         if args.path_only {
             println!("{}", existing.display());
         } else {
@@ -79,6 +101,8 @@ pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
         }
         return Ok(());
     }
+    let source = repo.source.clone();
+    let name = repo_name(repo).to_owned();
     let target = repo_path(&catalog, repo)?;
     if target.exists() {
         bail!(
@@ -86,14 +110,15 @@ pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
             target.display()
         );
     }
-    eprintln!("↓ cloning {}", repo.source);
-    git::clone(&repo.source, &target)?;
+    eprintln!("↓ cloning {source}");
+    git::clone(&source, &target)?;
     let target = absolute(&target)?;
-    catalog::remember_local_path(cli, &repo.source, &target)?;
+    remember_new_clone(&mut catalog.repos[index], &target);
+    catalog::save(&catalog_path, &catalog)?;
     if args.path_only {
         println!("{}", target.display());
     } else {
-        println!("Ensured {} at {}", repo_name(repo), target.display());
+        println!("Ensured {name} at {}", target.display());
     }
     Ok(())
 }
@@ -102,7 +127,7 @@ pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
 pub fn path_command(cli: &Cli, args: &SelectorArgs) -> Result<()> {
     let (_, catalog) = catalog::load_or_initialize(cli)?;
     let repo = catalog::select(&catalog, &args.selector)?;
-    let Some(path) = locations::present_path(cli, &catalog, repo)? else {
+    let Some(path) = locations::present_path(&catalog, repo)? else {
         bail!(
             "repository is missing locally: {}",
             locations::managed_path(&catalog, repo)?.display()
@@ -155,14 +180,15 @@ fn confirm_restore(cli: &Cli, args: &RestoreArgs, count: usize) -> Result<bool> 
 }
 
 /// Clone one missing repository while preserving any existing path conflict.
-fn restore_one(cli: &Cli, catalog: &Catalog, repo: &crate::model::Repo) -> Result<()> {
-    if let Some(path) = locations::present_path(cli, catalog, repo)? {
+fn restore_one(catalog: &mut Catalog, index: usize) -> Result<bool> {
+    let repo = &catalog.repos[index];
+    if let Some(path) = locations::present_path(catalog, repo)? {
         println!(
             "✓ {} already present at {}",
             repo_name(repo),
             path.display()
         );
-        return Ok(());
+        return Ok(false);
     }
     let target = repo_path(catalog, repo)?;
     if target.exists() {
@@ -174,7 +200,19 @@ fn restore_one(cli: &Cli, catalog: &Catalog, repo: &crate::model::Repo) -> Resul
     } else {
         eprintln!("↓ cloning {}", repo.source);
         git::clone(&repo.source, &target)?;
-        catalog::remember_local_path(cli, &repo.source, &target)?;
+        let target = absolute(&target)?;
+        remember_new_clone(&mut catalog.repos[index], &target);
     }
-    Ok(())
+    Ok(true)
+}
+
+/// Add a just-created canonical clone to the one catalog file and prefer it if needed.
+fn remember_new_clone(repo: &mut crate::model::Repo, path: &std::path::Path) {
+    let replace_primary = repo
+        .primary_path()
+        .is_none_or(|primary| !git::is_repo(&primary));
+    repo.add_path(path.to_path_buf());
+    if replace_primary {
+        repo.primary = Some(path.display().to_string());
+    }
 }

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -6,11 +6,11 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::{
     catalog::{self, catalog_path, repo_name},
-    cli::{Cli, FilterArgs, ListArgs},
+    cli::{Cli, FilterArgs, ListArgs, LocationsArgs},
     identity::normalize_identity,
     locations,
     model::{Catalog, ListOutput, Repo, RepoOutput},
@@ -29,7 +29,7 @@ pub fn status(cli: &Cli, filter: &FilterArgs) -> Result<()> {
     }
     println!("Catalog: {}", catalog_path(cli)?.display());
     println!("Root:    {}\n", root_path(&catalog)?.display());
-    print_grouped_status(cli, &catalog, repos)?;
+    print_grouped_status(&catalog, repos)?;
     print_uncatalogued(&catalog)
 }
 
@@ -39,7 +39,7 @@ pub fn list(cli: &Cli, args: &ListArgs) -> Result<()> {
     let max_age = args.stale.as_deref().map(parse_duration).transpose()?;
     let repos = catalog::filtered(&catalog, &args.filter)
         .filter(|repo| {
-            let path = locations::present_path(cli, &catalog, repo).ok().flatten();
+            let path = locations::present_path(&catalog, repo).ok().flatten();
             (!args.missing || path.is_none())
                 && max_age.is_none_or(|age| path.is_some_and(|path| stale(&path, age)))
         })
@@ -52,23 +52,24 @@ pub fn list(cli: &Cli, args: &ListArgs) -> Result<()> {
             "{:<24} {:<10} {}",
             normalize_identity(&repo.source)?,
             repo.state,
-            observed_state(cli, &catalog, repo)?
+            observed_state(&catalog, repo)?
         );
     }
     Ok(())
 }
 
 /// Describe a repository's local presence without changing it.
-fn observed_state(cli: &Cli, catalog: &Catalog, repo: &Repo) -> Result<String> {
-    if let Some(path) = locations::present_path(cli, catalog, repo)? {
+fn observed_state(catalog: &Catalog, repo: &Repo) -> Result<String> {
+    if let Some(path) = locations::present_path(catalog, repo)? {
         return Ok(if stale(&path, Duration::from_secs(180 * 86400)) {
             "present (stale candidate)".into()
         } else {
             "present".into()
         });
     }
-    let remembered_exists =
-        locations::remembered_path(cli, repo)?.is_some_and(|path| path.exists());
+    let remembered_exists = locations::remembered_paths(repo)?
+        .iter()
+        .any(|path| path.exists());
     let managed = locations::managed_path(catalog, repo)?;
     Ok(if remembered_exists || managed.exists() {
         "invalid".into()
@@ -78,18 +79,18 @@ fn observed_state(cli: &Cli, catalog: &Catalog, repo: &Repo) -> Result<String> {
 }
 
 /// Emit the stable JSON contract shared by status and list.
-fn print_json(cli: &Cli, catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
+fn print_json(_cli: &Cli, catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
     let repositories = repos
         .into_iter()
         .map(|repo| {
-            let path = locations::present_path(cli, catalog, repo)?
+            let path = locations::present_path(catalog, repo)?
                 .unwrap_or(locations::managed_path(catalog, repo)?);
             Ok(RepoOutput {
                 identity: normalize_identity(&repo.source)?,
                 name: repo_name(repo).to_owned(),
                 path: absolute(&path)?.display().to_string(),
                 declared_state: repo.state,
-                observed_state: observed_state(cli, catalog, repo)?,
+                observed_state: observed_state(catalog, repo)?,
                 tags: repo.tags.clone(),
                 note: repo.note.clone(),
             })
@@ -105,8 +106,8 @@ fn print_json(cli: &Cli, catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
     Ok(())
 }
 
-/// Print lifecycle sections and local state for each selected repository.
-fn print_grouped_status(cli: &Cli, catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
+/// Print lifecycle sections and catalogued clone paths for each repository.
+fn print_grouped_status(catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
     if repos.is_empty() {
         println!("No repositories are catalogued yet.");
         println!("  Add the current repository:  shu add .");
@@ -120,15 +121,15 @@ fn print_grouped_status(cli: &Cli, catalog: &Catalog, repos: Vec<&Repo>) -> Resu
             current = Some(repo.state);
             println!("{}", repo.state.to_string().to_uppercase());
         }
-        print_repository_status(cli, catalog, repo)?;
+        print_repository_status(catalog, repo)?;
     }
     println!("\nEdit metadata: shu edit <repository> --state <state> --note <text>");
     Ok(())
 }
 
 /// Print one status entry with the expected path and next action when missing.
-fn print_repository_status(cli: &Cli, catalog: &Catalog, repo: &Repo) -> Result<()> {
-    let observed = observed_state(cli, catalog, repo)?;
+fn print_repository_status(catalog: &Catalog, repo: &Repo) -> Result<()> {
+    let observed = observed_state(catalog, repo)?;
     let marker = match observed.as_str() {
         value if value.starts_with("present") => ui::success_marker(),
         "missing" => ui::warning_marker(),
@@ -137,22 +138,108 @@ fn print_repository_status(cli: &Cli, catalog: &Catalog, repo: &Repo) -> Result<
     println!("  {marker} {:<18} {observed}", repo_name(repo));
 
     if observed == "missing" {
-        if let Some(path) = locations::remembered_path(cli, repo)? {
+        for path in locations::remembered_paths(repo)? {
             println!("    Recorded: {}", path.display());
         }
         let path = locations::managed_path(catalog, repo)?;
         println!("    Expected: {}", path.display());
         println!("    Clone:    shu ensure {}", repo_name(repo));
-    } else if let Some(path) = locations::present_path(cli, catalog, repo)?
-        && path != locations::managed_path(catalog, repo)?
-    {
-        println!("    Local:    {}", path.display());
+    } else {
+        let primary = locations::present_path(catalog, repo)?;
+        let paths = locations::present_paths(catalog, repo)?;
+        let managed = locations::managed_path(catalog, repo)?;
+        if paths.len() > 1 || paths.first().is_some_and(|path| path != &managed) {
+            println!("    Clones:");
+            for path in paths {
+                let marker = if primary.as_ref() == Some(&path) {
+                    "*"
+                } else {
+                    "·"
+                };
+                println!("      {marker} {}", path.display());
+            }
+        }
     }
     if let Some(note) = &repo.note {
         println!("    Note:     {note}");
     }
     if !repo.tags.is_empty() {
         println!("    Tags:     {}", repo.tags.join(", "));
+    }
+    Ok(())
+}
+
+/// Show known clone paths or select the preferred clone for one repository.
+pub fn locations_command(cli: &Cli, args: &LocationsArgs) -> Result<()> {
+    let (catalog_path, mut catalog) = catalog::load_or_initialize(cli)?;
+    let index = catalog::select_index(&catalog, &args.selector)?;
+    if let Some(path) = &args.primary {
+        let path = absolute(path)?;
+        let path = if crate::git::is_repo(&path) {
+            crate::git::worktree_root(&path)?
+        } else {
+            path
+        };
+        let name = catalog::repo_name(&catalog.repos[index]).to_owned();
+        let is_recorded = catalog.repos[index]
+            .paths
+            .iter()
+            .any(|known| known == &path.display().to_string());
+        let is_managed = path == locations::managed_path(&catalog, &catalog.repos[index])?
+            && crate::git::is_repo(&path);
+        if !is_recorded && !is_managed {
+            bail!(
+                "{} is not a known clone for {}; run `shu add .` from that clone first",
+                path.display(),
+                name
+            );
+        }
+        if !is_recorded {
+            catalog.repos[index].add_path(path.clone());
+        }
+        catalog.repos[index].primary = Some(path.display().to_string());
+        catalog::save(&catalog_path, &catalog)?;
+        println!("Preferred clone for {name}: {}", path.display());
+    }
+
+    let repo = &catalog.repos[index];
+    let primary = locations::present_path(&catalog, repo)?;
+    let mut paths = locations::remembered_paths(repo)?;
+    let managed = locations::managed_path(&catalog, repo)?;
+    if crate::git::is_repo(&managed) && !paths.iter().any(|path| path == &managed) {
+        paths.push(managed);
+    }
+    if paths.is_empty() {
+        println!("No clone paths are recorded for {}.", repo_name(repo));
+        println!("  Add an existing clone: shu add .");
+        println!("  Create the managed clone: shu ensure {}", repo_name(repo));
+        return Ok(());
+    }
+    println!("{}", repo_name(repo));
+    for path in paths {
+        let marker = if primary.as_ref() == Some(&path) {
+            "*"
+        } else {
+            "·"
+        };
+        let state = if crate::git::is_repo(&path) {
+            "present"
+        } else {
+            "missing"
+        };
+        println!("  {marker} {state:<7} {}", path.display());
+    }
+    let worktrees = locations::pickable_paths(&catalog, repo)?;
+    let clone_paths = locations::present_paths(&catalog, repo)?;
+    let linked = worktrees
+        .into_iter()
+        .filter(|path| !clone_paths.contains(path))
+        .collect::<Vec<_>>();
+    if !linked.is_empty() {
+        println!("  Worktrees:");
+        for path in linked {
+            println!("    · {}", path.display());
+        }
     }
     Ok(())
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -57,11 +57,25 @@ pub fn is_clean(path: &Path) -> Result<bool> {
 
 /// Return whether Git reports another linked working tree for this repository.
 pub fn has_linked_worktrees(path: &Path) -> Result<bool> {
-    let count = output(path, ["worktree", "list", "--porcelain"])?
+    Ok(worktrees(path)?.len() > 1)
+}
+
+/// Return every working-tree path Git associates with a local repository.
+///
+/// The first entry is normally the main working tree and later entries are
+/// linked worktrees. Paths are read from Git each time so Shu never stores
+/// worktree state in `shu.toml`.
+pub fn worktrees(path: &Path) -> Result<Vec<PathBuf>> {
+    output(path, ["worktree", "list", "--porcelain"])?
         .lines()
-        .filter(|line| line.starts_with("worktree "))
-        .count();
-    Ok(count > 1)
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(|value| {
+            let path = PathBuf::from(value);
+            fs::canonicalize(&path)
+                .map(presentation_path)
+                .with_context(|| format!("could not resolve Git worktree {}", path.display()))
+        })
+        .collect()
 }
 
 /// Run Git in a working directory and return trimmed standard output on success.

--- a/src/locations.rs
+++ b/src/locations.rs
@@ -1,16 +1,14 @@
-//! Resolution of a repository's observed and managed local locations.
+//! Resolution of a repository's managed, remembered, and Git worktree paths.
 //!
-//! `shu.toml` remains portable and therefore contains no machine-specific
-//! paths. This module combines its canonical destination with the local
-//! observation sidecar written by commands such as `shu add .`.
+//! `shu.toml` owns repository identities and the clone paths Shu remembers
+//! after `shu add .`. This module asks Git for linked worktrees when they are
+//! needed, without ever storing worktree state itself.
 
 use std::path::PathBuf;
 
 use anyhow::Result;
 
 use crate::{
-    catalog,
-    cli::Cli,
     git,
     model::{Catalog, Repo},
     paths::{absolute, repo_path},
@@ -21,23 +19,73 @@ pub fn managed_path(catalog: &Catalog, repo: &Repo) -> Result<PathBuf> {
     absolute(&repo_path(catalog, repo)?)
 }
 
-/// Return an explicitly remembered path, even if the directory is no longer valid.
-pub fn remembered_path(cli: &Cli, repo: &Repo) -> Result<Option<PathBuf>> {
-    catalog::remembered_local_path(cli, &repo.source)?
+/// Return every remembered clone path, including paths that have gone stale.
+pub fn remembered_paths(repo: &Repo) -> Result<Vec<PathBuf>> {
+    repo.paths
+        .iter()
+        .map(PathBuf::from)
         .map(|path| absolute(&path))
-        .transpose()
+        .collect()
 }
 
-/// Return the present local clone, preferring a remembered existing location.
+/// Return the explicitly selected clone path, including a stale path.
+pub fn primary_path(repo: &Repo) -> Result<Option<PathBuf>> {
+    repo.primary_path().map(|path| absolute(&path)).transpose()
+}
+
+/// Return every valid full clone known for a repository on this machine.
 ///
-/// If the observation is stale, Shu falls back to the managed destination so
-/// a restored or migrated clone continues to work without cache cleanup.
-pub fn present_path(cli: &Cli, catalog: &Catalog, repo: &Repo) -> Result<Option<PathBuf>> {
-    if let Some(path) = remembered_path(cli, repo)?
-        && git::is_repo(&path)
-    {
-        return Ok(Some(path));
-    }
+/// Catalog paths preserve their registration order. The derived managed
+/// location is included when it is a valid repository even if it is absent
+/// from the catalog's `paths` list.
+pub fn present_paths(catalog: &Catalog, repo: &Repo) -> Result<Vec<PathBuf>> {
+    let mut paths = remembered_paths(repo)?
+        .into_iter()
+        .filter(|path| git::is_repo(path))
+        .collect::<Vec<_>>();
     let managed = managed_path(catalog, repo)?;
-    Ok(git::is_repo(&managed).then_some(managed))
+    if git::is_repo(&managed) && !paths.iter().any(|path| path == &managed) {
+        paths.push(managed);
+    }
+    Ok(paths)
+}
+
+/// Return the preferred present clone path for commands that require one path.
+///
+/// An explicitly selected, valid primary clone wins. Otherwise Shu uses the
+/// first valid remembered path, then the canonical managed location.
+pub fn present_path(catalog: &Catalog, repo: &Repo) -> Result<Option<PathBuf>> {
+    if let Some(primary) = primary_path(repo)?
+        && git::is_repo(&primary)
+    {
+        return Ok(Some(primary));
+    }
+    Ok(present_paths(catalog, repo)?.into_iter().next())
+}
+
+/// Return all present clone and linked-worktree paths for picker discovery.
+///
+/// Git worktrees remain Git-owned state: Shu reads them dynamically and does
+/// not store them in `shu.toml`.
+pub fn pickable_paths(catalog: &Catalog, repo: &Repo) -> Result<Vec<PathBuf>> {
+    let clones = present_paths(catalog, repo)?;
+    let primary = present_path(catalog, repo)?;
+    let mut paths = Vec::new();
+    if let Some(primary) = primary {
+        paths.push(primary);
+    }
+    for clone in clones {
+        push_unique(&mut paths, clone.clone());
+        for worktree in git::worktrees(&clone)? {
+            push_unique(&mut paths, worktree);
+        }
+    }
+    Ok(paths)
+}
+
+/// Remove duplicate filesystem paths while retaining the first useful order.
+fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|known| known == &path) {
+        paths.push(path);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn run() -> Result<()> {
         Some(Commands::Upgrade(args)) => commands::upgrade(args),
         Some(Commands::Ensure(args)) => commands::ensure(&cli, args),
         Some(Commands::Path(args)) => commands::path_command(&cli, args),
+        Some(Commands::Locations(args)) => commands::locations_command(&cli, args),
         Some(Commands::List(args)) => commands::list(&cli, args),
         Some(Commands::State(args)) => commands::change_state(&cli, &args.selector, args.state),
         Some(Commands::Archive(args)) => {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,6 @@
-//! Portable TOML catalog types and machine-readable output structures.
+//! `shu.toml` types and machine-readable output structures.
+
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -30,7 +32,7 @@ impl std::fmt::Display for Lifecycle {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-/// The portable desired state stored in `shu.toml`.
+/// The complete user-facing Shu configuration stored in `shu.toml`.
 pub struct Catalog {
     /// Catalog format version.
     pub version: u32,
@@ -43,7 +45,7 @@ pub struct Catalog {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-/// One desired repository and its human-maintained metadata.
+/// One catalogued repository, its human-maintained metadata, and local clones.
 pub struct Repo {
     /// Normalized `host/namespace/repository` identity.
     pub source: String,
@@ -56,6 +58,43 @@ pub struct Repo {
     /// Optional context explaining why the repository is retained.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Full clone roots known for this repository on the current machine.
+    ///
+    /// Paths are intentionally stored in the single `shu.toml` catalog so the
+    /// user can inspect and edit all Shu state in one readable file. Missing
+    /// paths are harmless on another machine; Shu simply ignores them until a
+    /// valid local clone exists.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    /// Preferred local clone path used when a command needs one destination.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary: Option<String>,
+}
+
+impl Repo {
+    /// Add a clone path once, preserving the order in which paths were added.
+    pub fn add_path(&mut self, path: PathBuf) {
+        let value = path.display().to_string();
+        if !self.paths.iter().any(|known| known == &value) {
+            self.paths.push(value);
+        }
+    }
+
+    /// Replace a moved clone path and make its destination the preferred clone.
+    pub fn replace_path(&mut self, source: &Path, destination: PathBuf) {
+        let source = source.display().to_string();
+        let destination = destination.display().to_string();
+        self.paths.retain(|known| known != &source);
+        if !self.paths.iter().any(|known| known == &destination) {
+            self.paths.push(destination.clone());
+        }
+        self.primary = Some(destination);
+    }
+
+    /// Return the explicit preferred clone path, if the catalog has one.
+    pub fn primary_path(&self) -> Option<PathBuf> {
+        self.primary.as_ref().map(PathBuf::from)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -202,10 +202,7 @@ fn picks_a_local_repository_without_an_external_fuzzy_finder() {
         .join("github.com")
         .join("example-org")
         .join("api");
-    assert_eq!(
-        normalize_path(String::from_utf8(picked.stdout).unwrap().trim()),
-        normalize_path(&expected.to_string_lossy())
-    );
+    assert_same_path(String::from_utf8(picked.stdout).unwrap().trim(), &expected);
 }
 
 #[test]
@@ -345,7 +342,7 @@ fn records_an_existing_local_clone_without_migrating_or_overwriting_metadata() {
     let report = String::from_utf8(status.stdout).unwrap();
     assert!(report.contains("PARKED"));
     assert!(report.contains("present"));
-    assert!(report.contains("Local:"));
+    assert!(report.contains("Clones:"));
     assert!(report.contains("Keep the first working prototype."));
 
     fixture
@@ -357,6 +354,119 @@ fn records_an_existing_local_clone_without_migrating_or_overwriting_metadata() {
             "--clear-note",
         ])
         .assert_success();
+}
+
+#[test]
+fn records_multiple_clones_in_the_catalog_and_discovers_git_worktrees() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_catalog("library.toml");
+    let second = fixture.temp.path().join("second-clone");
+    let linked = fixture.temp.path().join("linked-worktree");
+
+    run_git(
+        fixture.temp.path(),
+        ["clone", fixture.seed.to_str().unwrap()],
+        Some(&second),
+    );
+    run_git(
+        &second,
+        [
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:example-org/api.git",
+        ],
+        None,
+    );
+
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "add",
+            fixture.seed.to_str().unwrap(),
+        ])
+        .assert_success();
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "add",
+            second.to_str().unwrap(),
+        ])
+        .assert_success();
+
+    let saved: toml::Value = toml::from_str(&fs::read_to_string(&catalog).unwrap()).unwrap();
+    let repo = &saved["repos"][0];
+    assert_eq!(repo["paths"].as_array().unwrap().len(), 2);
+    assert_same_path(repo["primary"].as_str().unwrap(), &fixture.seed);
+
+    let locations = fixture.shu(["--catalog", catalog.to_str().unwrap(), "locations", "api"]);
+    locations.assert_success();
+    let locations = String::from_utf8(locations.stdout).unwrap();
+    assert!(locations.contains("present"));
+    assert!(locations.contains("second-clone"));
+
+    let second_pick = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--filter",
+        "second-clone",
+        "--path-only",
+    ]);
+    second_pick.assert_success();
+    assert_same_path(
+        String::from_utf8(second_pick.stdout).unwrap().trim(),
+        &second,
+    );
+
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "locations",
+            "api",
+            "--primary",
+            second.to_str().unwrap(),
+        ])
+        .assert_success();
+    let primary = fixture.shu(["--catalog", catalog.to_str().unwrap(), "path", "api"]);
+    primary.assert_success();
+    assert_same_path(String::from_utf8(primary.stdout).unwrap().trim(), &second);
+
+    let primary_pick = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--filter",
+        "api",
+        "--path-only",
+    ]);
+    primary_pick.assert_success();
+    assert_same_path(
+        String::from_utf8(primary_pick.stdout).unwrap().trim(),
+        &second,
+    );
+
+    run_git(
+        &fixture.seed,
+        ["worktree", "add", "--detach"],
+        Some(&linked),
+    );
+    let worktree_pick = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--filter",
+        "linked-worktree",
+        "--path-only",
+    ]);
+    worktree_pick.assert_success();
+    assert_same_path(
+        String::from_utf8(worktree_pick.stdout).unwrap().trim(),
+        &linked,
+    );
 }
 
 #[test]

--- a/tests/docker/e2e.sh
+++ b/tests/docker/e2e.sh
@@ -36,10 +36,13 @@ shu --catalog "$workspace/shu.toml" doctor | grep -q '^✓ catalog:'
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$path"
 shu --catalog "$workspace/shu.toml" --json list | grep -q '"observed_state": "present"'
 
-# Normal add records an existing clone in local state without moving it. The
-# recorded location is then preferred by ensure and the picker.
+# Normal add records an existing clone in the one catalog without moving it.
+# That location is then preferred by ensure and the picker.
 git -C "$workspace/seed" remote set-url origin 'https://github.com/example-org/api.git'
 GIT_CONFIG_COUNT=0 shu --catalog "$workspace/shu.toml" add "$workspace/seed"
+# Adding a second clone preserves the current primary. Choose this clone only
+# when we explicitly want it to be the default for path-oriented commands.
+shu --catalog "$workspace/shu.toml" locations api --primary "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" ensure api --path-only)" = "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$workspace/seed"
 


### PR DESCRIPTION
## What changed
- Store each repository's clone paths and preferred path directly in the one shu.toml file.
- Add shu locations for inspecting paths and selecting a preferred clone.
- Discover real Git worktrees dynamically and include them in the picker.

## Why
A repository often has multiple independent clones now. Shu must preserve each clone instead of replacing the previous path, while keeping --migrate explicit.

## Validation
- cargo fmt -- --check
- cargo test
- cargo clippy --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --no-deps --document-private-items
- Docker end-to-end workflow