### PR TITLE
Merge v0.1.15 and strengthen workflow stress tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
+      - run: cargo fmt --check
+      - run: cargo clippy --locked --all-targets -- -D warnings
+      - run: cargo test --locked
       - run: cargo doc --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -D warnings
-      - run: cargo build --release
+      - run: cargo build --locked --release
       - name: Test PowerShell installer
         if: runner.os == 'Windows'
         shell: pwsh
@@ -32,13 +32,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: sh -n tests/docker/e2e.sh
       - run: docker build --tag shu:test .
-      - name: Run Docker end-to-end test
+      - name: Run Docker end-to-end test twice in fresh containers
         run: |
-          docker run --rm --entrypoint /bin/sh \
-            -v "$GITHUB_WORKSPACE/tests/docker:/tests:ro" \
-            -v "$GITHUB_WORKSPACE/scripts:/scripts:ro" \
-            shu:test -c 'sh /tests/e2e.sh'
+          for attempt in 1 2; do
+            echo "Docker E2E attempt $attempt"
+            docker run --rm --entrypoint /bin/sh \
+              -v "$GITHUB_WORKSPACE/tests/docker:/tests:ro" \
+              -v "$GITHUB_WORKSPACE/scripts:/scripts:ro" \
+              shu:test -c 'sh /tests/e2e.sh'
+          done
+
+  cli-stress:
+    name: CLI stress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - name: Repeat offline end-to-end suite
+        run: |
+          for attempt in 1 2 3; do
+            echo "CLI stress attempt $attempt"
+            cargo test --locked --test cli_workflows -- --test-threads=1
+          done
 
   release-size:
     name: Release size (${{ matrix.target }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.14] - 2026-07-28
+
+### Added
+
+- `shu sync init` now checks Git author configuration before creating a remote
+  and refuses already-populated catalog remotes with an activation hint.
+- `shu doctor` reports Git author readiness; `--check-source` now verifies that
+  the configured catalog remote and ref are reachable.
+- Explicit SSH remotes added through `shu add`, migration, or scan are retained
+  in `repos[].remote` so `shu ensure` and `shu restore` keep using SSH.
+
+### Changed
+
+- GitHub repositories created by `shu new --github` and `shu sync init --github`
+  are private by default; `--public` makes publication intentional.
+- `--json` now rejects commands without a stable JSON response contract.
+- The setup and sync documentation now describes the supported Git catalog flow,
+  command roles, and read-only Gist behavior.
+
 ## [0.1.13] - 2026-07-28
 
 ### Added
@@ -230,7 +249,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.14...HEAD
+[0.1.14]: https://github.com/wiedymi/shu/compare/v0.1.13...v0.1.14
 [0.1.11]: https://github.com/wiedymi/shu/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/wiedymi/shu/compare/v0.1.9...v0.1.10
 [0.1.6]: https://github.com/wiedymi/shu/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-07-28
+
+### Changed
+
+- Catalog sync now publishes only portable repository metadata while preserving
+  each machine's root, local clone paths, and preferred clone in its active
+  `shu.toml`.
+- Managed clone paths are recorded relative to the configured root, avoiding
+  usernames and absolute managed-library paths in local catalog entries.
+- Restoring a synced catalog merges portable metadata by repository identity,
+  then materializes missing repositories below the receiving machine's root.
+- Docker E2E installer coverage now selects the running Linux architecture.
+
 ## [0.1.14] - 2026-07-28
 
 ### Added
@@ -249,7 +262,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.14...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.15...HEAD
+[0.1.15]: https://github.com/wiedymi/shu/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/wiedymi/shu/compare/v0.1.13...v0.1.14
 [0.1.11]: https://github.com/wiedymi/shu/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/wiedymi/shu/compare/v0.1.9...v0.1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrite the README around the everyday flow: add or clone a repository, find
+  it, create one, and optionally sync the library to another machine.
+- Strengthen cross-platform validation with large-catalog restore and picker
+  coverage, repeated CLI and Docker end-to-end runs, and semantic Windows path
+  assertions.
+
 ## [0.1.15] - 2026-07-28
 
 ### Changed
@@ -265,8 +273,13 @@ and releases use [Semantic Versioning](https://semver.org/).
 [Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.15...HEAD
 [0.1.15]: https://github.com/wiedymi/shu/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/wiedymi/shu/compare/v0.1.13...v0.1.14
+[0.1.13]: https://github.com/wiedymi/shu/compare/v0.1.12...v0.1.13
+[0.1.12]: https://github.com/wiedymi/shu/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/wiedymi/shu/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/wiedymi/shu/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/wiedymi/shu/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/wiedymi/shu/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/wiedymi/shu/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/wiedymi/shu/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/wiedymi/shu/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/wiedymi/shu/compare/v0.1.3...v0.1.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Shu reads the repository's root-level `shu.toml`, puts missing repositories
 under `~/shu` by default, and leaves existing repositories alone. `shu add .`
 adds that current clone to the repository's `paths` list in the same catalog,
 so it remains available to `shu`, `shu path`, and the picker without an
-unnecessary move. If you start with an empty machine, everyday commands create
-an empty local catalog for you.
+unnecessary move. Those locations stay on the current machine. If you start
+with an empty machine, everyday commands create an empty local catalog for you.
 
 ## Install
 
@@ -129,28 +129,30 @@ state = "active"
 tags = ["personal", "rust"]
 note = "A project I work on regularly"
 paths = [
+  "github.com/your-name/project",
   "C:/Users/you/Projects/project",
-  "C:/Users/you/shu/github.com/your-name/project",
 ]
-primary = "C:/Users/you/Projects/project"
+primary = "github.com/your-name/project"
 ```
 
 | Field | Meaning | Default |
 | --- | --- | --- |
 | `version` | Catalog format version. | Required; currently `1`. |
-| `root` | Canonical destination used by `shu add`, `shu clone`, and `shu restore` for a repository that has no usable local clone. | `~/shu` |
+| `root` | Local canonical destination used by `shu add`, `shu clone`, and `shu restore` for a repository that has no usable local clone. | `~/shu` |
 | `repos[].source` | Repository identity: `host/namespace/repository`. HTTPS and SSH URLs are normalized to this form by `shu add`. | Required. |
 | `repos[].remote` | Explicit SSH transport preserved for later clones. Omitted for normal HTTPS cloning. | Optional. |
 | `repos[].state` | Your lifecycle label: `active`, `parked`, `reference`, or `archived`. It is never inferred from age. | `active` |
 | `repos[].tags` | Optional labels for filtering and grouping. | `[]` |
 | `repos[].note` | Optional human context about why the repository is kept. | Absent |
-| `repos[].paths` | Every known full clone of the repository. `shu add .` appends the current clone without moving it. | `[]` |
-| `repos[].primary` | The clone Shu prefers for `shu path` and the first picker result. | The first valid path, then the managed path. |
+| `repos[].paths` | Local full-clone paths. Paths below `root` are relative; external paths are absolute. | `[]` |
+| `repos[].primary` | Local clone preference for `shu path` and the first picker result. | The first valid path, then the managed path. |
 
-`paths` holds normal full-clone roots. A path that does not exist on the
-current computer is ignored safely, which makes one catalog usable across your
-machines. Git worktrees are deliberately not stored: Shu discovers them from
-each valid clone every time it opens the picker or runs `shu locations`.
+`paths`, `primary`, and `root` describe only the current machine. A managed
+path is stored relative to `root`, so `github.com/your-name/project` resolves
+to `~/shu/github.com/your-name/project` on one machine and that machine's
+configured root on another. An external clone remains absolute and local.
+Git worktrees are deliberately not stored: Shu discovers them from each valid
+clone every time it opens the picker or runs `shu locations`.
 
 `root` does not move anything by itself. It only determines the canonical
 managed destination:
@@ -281,7 +283,10 @@ It is not added to `[[repos]]`, so it never appears in your repository picker.
 `sync` uses your existing Git credentials. It refuses a dirty checkout or a
 remote change that has not been restored first; run `shu restore` again to
 review the remote version. It never stores credentials, force-pushes, resets,
-or merges changes.
+or merges changes. The synced Git catalog contains only portable repository
+metadata (`source`, `remote`, lifecycle, tags, notes, and `[sync]`). Local
+`root`, `paths`, and `primary` remain in each machine's active `shu.toml` and
+are merged back after `shu restore` or `shu update`.
 
 ## Command model
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,20 @@ project lives locally.
 
 ## Get started
 
-Create a catalog beside your other personal configuration, then commit it to a
-private repository or Gist:
+Create a private, synced catalog. This creates the GitHub repository, commits
+the initial `shu.toml`, and makes it your active catalog:
 
 ```sh
-shu --catalog ./shu.toml init
-shu --catalog ./shu.toml add .
-shu --catalog ./shu.toml add github.com/example-org/useful-project --state reference # clones it
-git add shu.toml
+shu doctor --check-github
+shu sync init github.com/you/shu-catalog --github
+shu add .
+shu add github.com/example-org/useful-project --state reference
+shu sync
 ```
+
+`--github` creates a private repository by default. Add `--public` only when
+you intentionally want a public repository. If you already created an empty
+remote with another provider, use `shu sync init <remote>` instead.
 
 On a new machine:
 
@@ -98,8 +103,8 @@ The picker offers repositories that are actually present on this machine,
 including every existing clone recorded with `shu add .` and real Git
 worktrees discovered dynamically from those clones. `--migrate` remains the
 explicit option to move a clean clone into Shu's managed root. If `shu status`
-shows a repository as **missing**, restore it with `shu add <repository>` or run
-`shu add .` from the existing clone to record it.
+shows a repository as **missing**, materialize it with `shu ensure <repository>`;
+run `shu add .` from an existing clone to record it.
 
 For scripts and agents:
 
@@ -135,6 +140,7 @@ primary = "C:/Users/you/Projects/project"
 | `version` | Catalog format version. | Required; currently `1`. |
 | `root` | Canonical destination used by `shu add`, `shu clone`, and `shu restore` for a repository that has no usable local clone. | `~/shu` |
 | `repos[].source` | Repository identity: `host/namespace/repository`. HTTPS and SSH URLs are normalized to this form by `shu add`. | Required. |
+| `repos[].remote` | Explicit SSH transport preserved for later clones. Omitted for normal HTTPS cloning. | Optional. |
 | `repos[].state` | Your lifecycle label: `active`, `parked`, `reference`, or `archived`. It is never inferred from age. | `active` |
 | `repos[].tags` | Optional labels for filtering and grouping. | `[]` |
 | `repos[].note` | Optional human context about why the repository is kept. | Absent |
@@ -218,10 +224,11 @@ repository explicitly, use the authenticated GitHub CLI:
 
 ```sh
 shu doctor --check-github
-shu new github.com/you/private-project --github --private
+shu new github.com/you/private-project --github
 ```
 
-`--github` is optional and provider-specific. If it is unavailable or lacks
+`--github` is optional and provider-specific; it creates a private repository
+unless you pass `--public`. If it is unavailable or lacks
 permission, Shu leaves the catalog unchanged and explains how to create the
 remote manually.
 
@@ -234,11 +241,12 @@ shu upgrade             # Install the latest verified Shu release
 
 ## Syncing a private catalog
 
-Shu does not create repositories or manage credentials. Create a private Git
-repository with your preferred provider, or let Shu create one through `gh`:
+Shu uses a normal Git checkout and your existing credentials; it does not store
+credentials or create sidecar state. Create an empty private Git repository
+with your preferred provider, or let Shu create one through `gh`:
 
 ```sh
-shu sync init github.com/you/shu-catalog --github --private
+shu sync init github.com/you/shu-catalog --github
 ```
 
 This creates a dedicated catalog checkout, commits the active catalog, pushes
@@ -249,20 +257,15 @@ This creates a dedicated catalog checkout, commits the active catalog, pushes
 shu doctor --check-github
 ```
 
-To use an already-created remote, run `shu sync init <remote>` instead. In
-both cases Shu writes this configuration into the catalog:
+To use an already-created remote, it must have no branches; run `shu sync init
+<remote>`. For a remote that already contains a Shu catalog, use `shu restore
+<remote>` instead. `sync init` writes this configuration into the catalog:
 
 ```toml
 [sync]
 remote = "git@github.com:you/shu-catalog.git"
 file = "shu.toml"
 ref = "main"
-```
-
-Then make it active once:
-
-```sh
-shu restore git@github.com:you/shu-catalog.git
 ```
 
 After changing the local catalog, publish it with:
@@ -279,6 +282,18 @@ It is not added to `[[repos]]`, so it never appears in your repository picker.
 remote change that has not been restored first; run `shu restore` again to
 review the remote version. It never stores credentials, force-pushes, resets,
 or merges changes.
+
+## Command model
+
+- `shu new`: create and catalogue a local repository.
+- `shu add` / `shu clone`: register an existing clone, or register and clone a remote.
+- `shu ensure`: materialize one already-catalogued repository and print its path.
+- `shu restore`: restore all missing repositories, optionally after loading a catalog source.
+- `shu sync`: commit and push catalog edits; `shu update`: pull catalog edits and restore missing repositories.
+
+A Git repository containing `shu.toml` can be restored only when that file has
+a matching `[sync]` table. A GitHub Gist is a read-only catalog source: it can
+be restored, but cannot be used with `shu sync` or `shu update`.
 
 If a clone or release download is unavailable, Shu reports what failed and
 suggests checking the path, network connection, or Git access. It does not try

--- a/README.md
+++ b/README.md
@@ -4,53 +4,17 @@
 [![Checks](https://img.shields.io/github/actions/workflow/status/wiedymi/shu/ci.yml?branch=main&style=flat-square&label=checks)](https://github.com/wiedymi/shu/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/wiedymi/shu?style=flat-square)](LICENSE)
 
-**Your simple library of Git repositories.**
+**A small, personal library for your Git repositories.**
 
-Shu keeps one small, readable `shu.toml` catalog of the repositories you care
-about. Put it in Git, restore it on a new computer, and always know where a
-project lives locally.
-
-- Restore your repository collection with one command.
-- Keep old projects as active, parked, reference, or archived—without deleting them.
-- Find a repository quickly with Shu's built-in fuzzy picker.
-- Give scripts and coding agents one reliable command for getting a local path.
-
-## Get started
-
-Create a private, synced catalog. This creates the GitHub repository, commits
-the initial `shu.toml`, and makes it your active catalog:
-
-```sh
-shu doctor --check-github
-shu sync init github.com/you/shu-catalog --github
-shu add .
-shu add github.com/example-org/useful-project --state reference
-shu sync
-```
-
-`--github` creates a private repository by default. Add `--public` only when
-you intentionally want a public repository. If you already created an empty
-remote with another provider, use `shu sync init <remote>` instead.
-
-On a new machine:
-
-```sh
-shu restore github.com/your-name/your-repository-library
-```
-
-Shu reads the repository's root-level `shu.toml`, puts missing repositories
-under `~/shu` by default, and leaves existing repositories alone. `shu add .`
-adds that current clone to the repository's `paths` list in the same catalog,
-so it remains available to `shu`, `shu path`, and the picker without an
-unnecessary move. Those locations stay on the current machine. If you start
-with an empty machine, everyday commands create an empty local catalog for you.
+Shu remembers the projects you care about, puts new clones in predictable
+places, and lets you jump to them quickly. Its catalog is a readable
+`shu.toml` file—your repositories stay normal Git repositories under your
+control.
 
 ## Install
 
 Download a release for macOS, Windows, or Linux from
-[GitHub Releases](https://github.com/wiedymi/shu/releases).
-
-Once stable releases are public, the simplest installation commands are:
+[GitHub Releases](https://github.com/wiedymi/shu/releases), or install it with:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf \
@@ -61,63 +25,162 @@ curl --proto '=https' --tlsv1.2 -LsSf \
 irm https://github.com/wiedymi/shu/releases/latest/download/shu-installer.ps1 | iex
 ```
 
-Both installers verify the downloaded archive against the release's
-`SHA256SUMS` file. To build Shu directly from source:
+The installers verify the download against the release checksums. To build
+from source instead:
 
 ```sh
 cargo install --git https://github.com/wiedymi/shu
 ```
 
-## Everyday use
+## Start here
+
+Add a project you already have, or clone one you want. Shu creates its local
+catalog automatically and uses `~/shu` as the default library root.
 
 ```sh
-shu                     # Pick a present repository and enter it (after shell setup)
-shu status              # See what is present, missing, or uncatalogued
-shu restore             # Clone catalogued repositories that are missing
-shu doctor              # Check Git, the catalog, and the configured root
-shu add github.com/you/my-project # Add and clone a repository
-shu clone github.com/you/my-project # Alias for `shu add`
-shu locations my-project # Show every known clone and its Git worktrees
-shu edit my-project --state parked --note "Paused until the next release"
-shu add . --migrate     # Move a clean local repository into ~/shu's layout
+# From inside an existing Git repository
+shu add .
+
+# Clone and remember a repository
+shu add github.com/example-org/api
+# `shu clone github.com/example-org/api` means the same thing.
 ```
 
-To make bare `shu` open the picker, install its small shell wrapper once:
+Now find it whenever you need it:
 
 ```sh
-# Use bash, zsh, fish, nushell, or posix as appropriate.
-shu shell init bash
+shu list
+shu path api
+shu pick
+```
+
+`shu path` prints the preferred local checkout. `shu pick` opens the fuzzy
+picker and returns the selected path. The shell integration below makes plain
+`shu` open that picker and change your current directory.
+
+## Everyday commands
+
+| What you want | Command |
+| --- | --- |
+| Add the current checkout without moving it | `shu add .` |
+| Clone a repository into your library | `shu add github.com/you/project` |
+| Create a fresh local repository | `shu new github.com/you/project` |
+| Find and open a project | `shu pick` or plain `shu` after shell setup |
+| Print a project path for a script | `shu path project` |
+| See clones and Git worktrees | `shu locations project` |
+| See what is missing locally | `shu status` |
+| Clone every missing catalogued project | `shu restore` |
+| Discover projects in a directory | `shu scan ~/Development --add` |
+| Check your setup | `shu doctor` |
+
+Repository names can be the full identity (`github.com/you/project`), a unique
+suffix, or a unique name such as `project`.
+
+### Pick and jump
+
+Install the tiny shell wrapper once:
+
+```sh
+# Pick the shell you use: bash, zsh, fish, nushell, or posix.
+shu shell init zsh
 ```
 
 ```powershell
 shu shell init pwsh
 ```
 
-Shu writes only a clearly marked block to the appropriate startup file and
-will replace that block safely when run again. Open a new terminal afterwards:
-a program cannot modify its parent shell's current session. To inspect or
-manage the wrapper yourself, use `shu shell init pwsh --print` or provide an
-explicit target with `shu shell init pwsh --path ./profile.ps1`.
+Open a new terminal afterwards. Then plain `shu` shows the fuzzy picker; choose
+a repository or one of its Git worktrees and your shell changes into it.
+`shu pick` remains useful when you only need the selected path.
 
-The picker offers repositories that are actually present on this machine,
-including every existing clone recorded with `shu add .` and real Git
-worktrees discovered dynamically from those clones. `--migrate` remains the
-explicit option to move a clean clone into Shu's managed root. If `shu status`
-shows a repository as **missing**, materialize it with `shu ensure <repository>`;
-run `shu add .` from an existing clone to record it.
+### Keep repositories organized
 
-For scripts and agents:
+Adding `.` records an existing checkout where it already lives. Adding a remote
+identity clones it below the library root:
 
-```sh
-repo_path="$(shu ensure github.com/example-org/project --path-only)"
+```text
+~/shu/github.com/you/project
 ```
 
-## `shu.toml` reference
+Mark projects for later without moving or deleting anything:
 
-`shu.toml` is Shu's only user-facing configuration file. It describes the
-repositories you care about and, when you add existing clones, the local paths
-where you keep them. There is one `[[repos]]` entry for each repository
-identity.
+```sh
+shu edit project --state parked --note "Waiting for the next release"
+shu edit project --state reference
+shu archive project
+```
+
+The available states are `active`, `parked`, `reference`, and `archived`.
+Shu never deletes repositories or resets working trees.
+
+If you want to bring a clean existing checkout into Shu's managed layout,
+preview the move first:
+
+```sh
+shu add . --migrate --dry-run
+shu add . --migrate
+```
+
+## Create a repository
+
+Create a new local Git repository in Shu's library:
+
+```sh
+shu new github.com/you/new-project --tag experiment
+```
+
+To also create a private GitHub repository and set it as `origin`, use the
+authenticated GitHub CLI:
+
+```sh
+shu doctor --check-github
+shu new github.com/you/private-project --github
+```
+
+Pass `--public` only when you explicitly want a public repository. If GitHub
+CLI is unavailable, create the remote yourself and add it with Git as usual.
+
+## Use the same library on another machine
+
+Sync is optional. It stores your catalog in a normal private Git repository,
+using the credentials you already use for Git. Shu does not store tokens or
+create extra state files.
+
+Create a private catalog repository automatically with GitHub CLI:
+
+```sh
+shu sync init github.com/you/shu-catalog --github
+```
+
+Or create an empty private repository with any Git host first, then point Shu
+at it:
+
+```sh
+shu sync init git@github.com:you/shu-catalog.git
+```
+
+After you change your catalog, publish it:
+
+```sh
+shu sync
+```
+
+On another machine, restore the catalog and its missing projects:
+
+```sh
+shu restore git@github.com:you/shu-catalog.git
+```
+
+The synced catalog contains repository identities, Git remotes, states, tags,
+and notes. Your local root and local checkout paths stay private to each
+machine, so restore places managed projects below that machine's root. The
+catalog repository itself is a normal checkout below the root, but it is not
+shown in Shu's repository list or picker.
+
+## `shu.toml`
+
+`shu.toml` is the only configuration file Shu creates. You can edit it by hand
+or use the commands above.
 
 ```toml
 version = 1
@@ -128,193 +191,33 @@ source = "github.com/your-name/project"
 state = "active"
 tags = ["personal", "rust"]
 note = "A project I work on regularly"
-paths = [
-  "github.com/your-name/project",
-  "C:/Users/you/Projects/project",
-]
+paths = ["github.com/your-name/project"]
 primary = "github.com/your-name/project"
-```
 
-| Field | Meaning | Default |
-| --- | --- | --- |
-| `version` | Catalog format version. | Required; currently `1`. |
-| `root` | Local canonical destination used by `shu add`, `shu clone`, and `shu restore` for a repository that has no usable local clone. | `~/shu` |
-| `repos[].source` | Repository identity: `host/namespace/repository`. HTTPS and SSH URLs are normalized to this form by `shu add`. | Required. |
-| `repos[].remote` | Explicit SSH transport preserved for later clones. Omitted for normal HTTPS cloning. | Optional. |
-| `repos[].state` | Your lifecycle label: `active`, `parked`, `reference`, or `archived`. It is never inferred from age. | `active` |
-| `repos[].tags` | Optional labels for filtering and grouping. | `[]` |
-| `repos[].note` | Optional human context about why the repository is kept. | Absent |
-| `repos[].paths` | Local full-clone paths. Paths below `root` are relative; external paths are absolute. | `[]` |
-| `repos[].primary` | Local clone preference for `shu path` and the first picker result. | The first valid path, then the managed path. |
-
-`paths`, `primary`, and `root` describe only the current machine. A managed
-path is stored relative to `root`, so `github.com/your-name/project` resolves
-to `~/shu/github.com/your-name/project` on one machine and that machine's
-configured root on another. An external clone remains absolute and local.
-Git worktrees are deliberately not stored: Shu discovers them from each valid
-clone every time it opens the picker or runs `shu locations`.
-
-`root` does not move anything by itself. It only determines the canonical
-managed destination:
-
-```text
-<root>/<host>/<namespace>/<repository>
-```
-
-For example, `github.com/your-name/project` with the default root belongs at:
-
-```text
-~/shu/github.com/your-name/project
-```
-
-Choose the preferred clone explicitly with:
-
-```sh
-shu locations project --primary /path/to/project
-```
-
-Inspect all known clones and dynamically discovered worktrees with:
-
-```sh
-shu locations project
-```
-
-To register another existing full clone, run this from inside it:
-
-```sh
-shu add .
-```
-
-The catalog is deliberately data-only: no secrets, setup hooks, or arbitrary
-commands. Shu never deletes repositories, resets a working tree, or overwrites
-a conflicting directory.
-
-When `shu status` says a repository is **missing**, Shu cannot find a recorded
-local clone or its canonical destination. It prints the expected path and the
-exact `shu add <repository>` command to create it. To update catalog
-metadata without changing repository files:
-
-```sh
-shu edit my-project --state reference --note "Useful implementation reference"
-shu edit my-project --clear-note
-```
-
-To bring an existing clean clone into Shu's managed layout, preview the move
-first, then confirm it:
-
-```sh
-shu add . --migrate --dry-run
-shu add . --migrate
-```
-
-Migration only moves valid, clean working trees. Shu refuses repositories with
-staged, unstaged, or untracked changes; linked Git worktrees; an existing
-canonical destination; or a destination on another filesystem. It never copies
-then deletes a repository as a fallback.
-
-## Creating repositories
-
-Create an empty local Git repository directly in Shu's managed layout:
-
-```sh
-shu new github.com/you/new-project --tag experiment
-```
-
-This creates and catalogues the local repository on its `main` branch. It does
-not create a hosted repository, commit, or push. To create the matching GitHub
-repository explicitly, use the authenticated GitHub CLI:
-
-```sh
-shu doctor --check-github
-shu new github.com/you/private-project --github
-```
-
-`--github` is optional and provider-specific; it creates a private repository
-unless you pass `--public`. If it is unavailable or lacks
-permission, Shu leaves the catalog unchanged and explains how to create the
-remote manually.
-
-## Updating
-
-```sh
-shu update              # Refresh the configured Git catalog and restore missing repositories
-shu upgrade             # Install the latest verified Shu release
-```
-
-## Syncing a private catalog
-
-Shu uses a normal Git checkout and your existing credentials; it does not store
-credentials or create sidecar state. Create an empty private Git repository
-with your preferred provider, or let Shu create one through `gh`:
-
-```sh
-shu sync init github.com/you/shu-catalog --github
-```
-
-This creates a dedicated catalog checkout, commits the active catalog, pushes
-`main`, and activates sync. The catalog checkout is intentionally not added to
-`[[repos]]`. Before using GitHub creation, verify the installed CLI:
-
-```sh
-shu doctor --check-github
-```
-
-To use an already-created remote, it must have no branches; run `shu sync init
-<remote>`. For a remote that already contains a Shu catalog, use `shu restore
-<remote>` instead. `sync init` writes this configuration into the catalog:
-
-```toml
 [sync]
 remote = "git@github.com:you/shu-catalog.git"
 file = "shu.toml"
 ref = "main"
 ```
 
-After changing the local catalog, publish it with:
+Paths below `root` are stored relative to it. A checkout at
+`github.com/your-name/project` therefore resolves to
+`~/shu/github.com/your-name/project` with the default root. Paths outside the
+root are absolute and stay on the machine where they were recorded. Git
+worktrees are discovered when needed rather than stored in the catalog.
+
+For scripts and coding agents, use `ensure` when a checkout may be missing:
 
 ```sh
-shu sync
+repo_path="$(shu ensure github.com/example-org/project --path-only)"
 ```
 
-Shu keeps that catalog as a normal checkout at the canonical path below your
-configured repository root (for example `~/shu/github.com/you/shu-catalog`).
-It is not added to `[[repos]]`, so it never appears in your repository picker.
-
-`sync` uses your existing Git credentials. It refuses a dirty checkout or a
-remote change that has not been restored first; run `shu restore` again to
-review the remote version. It never stores credentials, force-pushes, resets,
-or merges changes. The synced Git catalog contains only portable repository
-metadata (`source`, `remote`, lifecycle, tags, notes, and `[sync]`). Local
-`root`, `paths`, and `primary` remain in each machine's active `shu.toml` and
-are merged back after `shu restore` or `shu update`.
-
-## Command model
-
-- `shu new`: create and catalogue a local repository.
-- `shu add` / `shu clone`: register an existing clone, or register and clone a remote.
-- `shu ensure`: materialize one already-catalogued repository and print its path.
-- `shu restore`: restore all missing repositories, optionally after loading a catalog source.
-- `shu sync`: commit and push catalog edits; `shu update`: pull catalog edits and restore missing repositories.
-
-A Git repository containing `shu.toml` can be restored only when that file has
-a matching `[sync]` table. A GitHub Gist is a read-only catalog source: it can
-be restored, but cannot be used with `shu sync` or `shu update`.
-
-If a clone or release download is unavailable, Shu reports what failed and
-suggests checking the path, network connection, or Git access. It does not try
-to manage your credentials.
-
-## Help
+## More help
 
 ```sh
 shu --help
+shu <command> --help
 shu doctor --check-source
-```
-
-For implementation documentation:
-
-```sh
-cargo doc --no-deps --document-private-items --open
 ```
 
 ## Security

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -170,6 +170,7 @@ mod tests {
             repos: vec![
                 Repo {
                     source: "github.com/acme/widgets".into(),
+                    remote: None,
                     state: Lifecycle::Active,
                     tags: vec![],
                     note: None,
@@ -178,6 +179,7 @@ mod tests {
                 },
                 Repo {
                     source: "github.com/acme/api".into(),
+                    remote: None,
                     state: Lifecycle::Parked,
                     tags: vec![],
                     note: None,

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use anyhow::{Context, Result, anyhow, bail};
 use directories::ProjectDirs;
+use serde::Serialize;
 
 /// Return the active catalog path, honoring the global `--catalog` override.
 pub fn catalog_path(cli: &Cli) -> Result<PathBuf> {
@@ -69,6 +70,88 @@ pub fn save(path: &Path, catalog: &Catalog) -> Result<()> {
     fs::create_dir_all(parent)?;
     fs::write(path, toml::to_string_pretty(catalog)?)
         .with_context(|| format!("could not write catalog {}", path.display()))
+}
+
+/// Serialize only the catalog fields that are meaningful on every machine.
+pub fn portable_contents(catalog: &Catalog) -> Result<String> {
+    toml::to_string_pretty(&PortableCatalog::from(catalog)).map_err(Into::into)
+}
+
+/// Save the portable catalog projection to the dedicated sync checkout.
+pub fn save_portable(path: &Path, catalog: &Catalog) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("catalog path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, portable_contents(catalog)?)
+        .with_context(|| format!("could not write catalog {}", path.display()))
+}
+
+/// Merge remote repository metadata while retaining this machine's locations.
+pub fn merge_portable(local: &mut Catalog, portable: Catalog) -> Result<()> {
+    if portable.version != 1 {
+        bail!("unsupported catalog version {}", portable.version);
+    }
+    let mut local_repos = std::mem::take(&mut local.repos)
+        .into_iter()
+        .map(|repo| Ok((normalize_identity(&repo.source)?, repo)))
+        .collect::<Result<std::collections::HashMap<_, _>>>()?;
+    local.repos = portable
+        .repos
+        .into_iter()
+        .map(|mut repo| {
+            if let Some(previous) = local_repos.remove(&normalize_identity(&repo.source)?) {
+                repo.paths = previous.paths;
+                repo.primary = previous.primary;
+            }
+            Ok(repo)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    local.sync = portable.sync;
+    Ok(())
+}
+
+/// The schema written to the synced Git catalog.
+#[derive(Serialize)]
+struct PortableCatalog<'a> {
+    version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sync: Option<&'a crate::model::Sync>,
+    repos: Vec<PortableRepo<'a>>,
+}
+
+impl<'a> From<&'a Catalog> for PortableCatalog<'a> {
+    fn from(catalog: &'a Catalog) -> Self {
+        Self {
+            version: catalog.version,
+            sync: catalog.sync.as_ref(),
+            repos: catalog.repos.iter().map(PortableRepo::from).collect(),
+        }
+    }
+}
+
+/// Portable metadata for one repository.
+#[derive(Serialize)]
+struct PortableRepo<'a> {
+    source: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote: Option<&'a String>,
+    state: crate::model::Lifecycle,
+    tags: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<&'a String>,
+}
+
+impl<'a> From<&'a Repo> for PortableRepo<'a> {
+    fn from(repo: &'a Repo) -> Self {
+        Self {
+            source: &repo.source,
+            remote: repo.remote.as_ref(),
+            state: repo.state,
+            tags: &repo.tags,
+            note: repo.note.as_ref(),
+        }
+    }
 }
 
 /// Resolve `.` or a local repository path to its origin remote; pass other values through.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,11 +24,11 @@ pub struct Cli {
         help = "Use a specific catalog file"
     )]
     pub catalog: Option<PathBuf>,
-    /// Emit structured output for scripts and agents.
+    /// Emit structured output for supported read-only commands.
     #[arg(
         long,
         global = true,
-        help = "Emit stable, versioned JSON where supported"
+        help = "Emit stable, versioned JSON for list, status, doctor, or scan"
     )]
     pub json: bool,
     /// Fail instead of displaying a confirmation prompt.
@@ -142,6 +142,9 @@ pub struct NewArgs {
     /// Create the GitHub repository as private; requires --github.
     #[arg(long, requires = "github")]
     pub private: bool,
+    /// Create the GitHub repository as public; private is the safe default.
+    #[arg(long, requires = "github", conflicts_with = "private")]
+    pub public: bool,
 }
 
 /// Arguments for `shu sync`.
@@ -170,6 +173,9 @@ pub struct SyncInitArgs {
     /// Create the GitHub repository as private; requires --github.
     #[arg(long, requires = "github")]
     pub private: bool,
+    /// Create the GitHub repository as public; private is the safe default.
+    #[arg(long, requires = "github", conflicts_with = "private")]
+    pub public: bool,
 }
 
 /// Arguments for `shu edit`.
@@ -202,7 +208,7 @@ pub struct ScanArgs {
 /// Arguments for `shu doctor`.
 #[derive(Args, Default)]
 pub struct DoctorArgs {
-    /// Resolve the remembered catalog source to confirm it is currently reachable.
+    /// Check the remembered catalog checkout and verify its remote is reachable.
     #[arg(long)]
     pub check_source: bool,
     /// Verify that gh is installed and authenticated for `shu new --github`.

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -630,7 +630,7 @@ pub(super) fn discover_repos(root: &Path) -> Result<Vec<(PathBuf, String, Option
             found.push((entry.path().to_path_buf(), identity, ssh_transport(&remote)));
         }
     }
-    found.sort_by(|left, right| left.1.cmp(&right.1));
+    found.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
     Ok(found)
 }
 

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -17,6 +17,7 @@ use crate::{
     commands::restore,
     git,
     identity::normalize_identity,
+    locations,
     model::{Catalog, Lifecycle, Repo},
     paths::{absolute, root_path},
     ui,
@@ -56,12 +57,11 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     let local_path = local_source_path(&args.source)?;
     if let Some(index) = existing_repo_index(&catalog, &identity) {
         if let Some(local_path) = local_path {
-            let repo = &mut catalog.repos[index];
-            if repo.remote.is_none() {
-                repo.remote = remote;
+            if catalog.repos[index].remote.is_none() {
+                catalog.repos[index].remote = remote;
             }
-            remember_path(repo, &local_path)?;
-            let name = catalog::repo_name(repo).to_owned();
+            remember_path(&mut catalog, index, &local_path)?;
+            let name = catalog::repo_name(&catalog.repos[index]).to_owned();
             catalog::save(&path, &catalog)?;
             println!("Already catalogued {name}");
             println!("  Local clone: {}", local_path.display());
@@ -78,10 +78,8 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     }
     add_entry(&mut catalog, args, &identity, remote);
     if let Some(local_path) = &local_path {
-        remember_path(
-            catalog.repos.last_mut().expect("entry was just added"),
-            local_path,
-        )?;
+        let index = catalog.repos.len() - 1;
+        remember_path(&mut catalog, index, local_path)?;
     }
     let index = catalog.repos.len() - 1;
     let local_path = match local_path {
@@ -126,10 +124,8 @@ pub fn new(cli: &Cli, args: &NewArgs) -> Result<()> {
         &args.tag,
         args.note.clone(),
     );
-    remember_path(
-        catalog.repos.last_mut().expect("entry was just added"),
-        &target,
-    )?;
+    let index = catalog.repos.len() - 1;
+    remember_path(&mut catalog, index, &target)?;
     catalog::save(&catalog_path, &catalog)?;
     println!("Created {identity}");
     println!("  Local repository: {}", target.display());
@@ -205,7 +201,9 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
             existing,
             false,
         )?;
-        replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
+        let index = existing_repo_index(catalog, &identity)
+            .expect("catalog entry was added or already present");
+        replace_path(catalog, index, &source, &destination)?;
         catalog::save(path, catalog)?;
         return Ok(());
     }
@@ -275,7 +273,9 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
         existing,
         true,
     )?;
-    replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
+    let index = existing_repo_index(catalog, &identity)
+        .expect("catalog entry was added or already present");
+    replace_path(catalog, index, &source, &destination)?;
     catalog::save(path, catalog)
 }
 
@@ -384,9 +384,10 @@ fn finish_catalog_add(
     moved: bool,
 ) -> Result<()> {
     if existing {
-        let repo = catalog_repo_mut(catalog, identity)?;
-        if repo.remote.is_none() {
-            repo.remote = remote;
+        let index = existing_repo_index(catalog, identity)
+            .expect("existing repository was checked before migration");
+        if catalog.repos[index].remote.is_none() {
+            catalog.repos[index].remote = remote;
         }
         println!(
             "  {} Preserved existing catalog metadata",
@@ -417,15 +418,6 @@ fn existing_repo_index(catalog: &Catalog, identity: &str) -> Option<usize> {
         .repos
         .iter()
         .position(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
-}
-
-/// Return the mutable catalog entry for an identity that was just materialized.
-fn catalog_repo_mut<'a>(catalog: &'a mut Catalog, identity: &str) -> Result<&'a mut Repo> {
-    catalog
-        .repos
-        .iter_mut()
-        .find(|repo| normalize_identity(&repo.source).ok().as_deref() == Some(identity))
-        .ok_or_else(|| anyhow!("catalog entry disappeared for {identity}"))
 }
 
 /// Add one catalog entry using the metadata supplied to `shu add`.
@@ -467,21 +459,36 @@ fn ssh_transport(source: &str) -> Option<String> {
 }
 
 /// Remember a clone path and choose it only when the current primary is invalid.
-fn remember_path(repo: &mut Repo, path: &Path) -> Result<()> {
+fn remember_path(catalog: &mut Catalog, index: usize, path: &Path) -> Result<()> {
     let path = absolute(path)?;
-    let replace_primary = repo
-        .primary_path()
+    let replace_primary = locations::primary_path(catalog, &catalog.repos[index])?
         .is_none_or(|primary| !git::is_repo(&primary));
-    repo.add_path(path.clone());
+    let stored = locations::store_local_path(catalog, &path)?;
+    let repo = &mut catalog.repos[index];
+    if !repo.paths.iter().any(|known| known == &stored) {
+        repo.paths.push(stored.clone());
+    }
     if replace_primary {
-        repo.primary = Some(path.display().to_string());
+        repo.primary = Some(stored);
     }
     Ok(())
 }
 
 /// Replace a moved source path with its canonical destination and prefer it.
-fn replace_path(repo: &mut Repo, source: &Path, destination: &Path) -> Result<()> {
-    repo.replace_path(&absolute(source)?, absolute(destination)?);
+fn replace_path(
+    catalog: &mut Catalog,
+    index: usize,
+    source: &Path,
+    destination: &Path,
+) -> Result<()> {
+    let source = locations::store_local_path(catalog, source)?;
+    let destination = locations::store_local_path(catalog, destination)?;
+    let repo = &mut catalog.repos[index];
+    repo.paths.retain(|known| known != &source);
+    if !repo.paths.iter().any(|known| known == &destination) {
+        repo.paths.push(destination.clone());
+    }
+    repo.primary = Some(destination);
     Ok(())
 }
 
@@ -654,11 +661,12 @@ fn import_discovered(cli: &Cli, found: &[(PathBuf, String, Option<String>)]) -> 
             });
             added += 1;
         }
-        let repo = catalog_repo_mut(&mut catalog, identity)?;
-        if repo.remote.is_none() {
-            repo.remote = remote.clone();
+        let index = existing_repo_index(&catalog, identity)
+            .expect("discovered repository was added or already present");
+        if catalog.repos[index].remote.is_none() {
+            catalog.repos[index].remote = remote.clone();
         }
-        remember_path(repo, local_path)?;
+        remember_path(&mut catalog, index, local_path)?;
     }
     catalog::save(&path, &catalog)?;
     println!("Added {added} repository entries to {}", path.display());

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -50,11 +50,16 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
     if args.migrate {
         return migrate_and_add(cli, args, &path, &mut catalog);
     }
-    let identity = normalize_identity(&catalog::source_from_argument(&args.source)?)?;
+    let source = catalog::source_from_argument(&args.source)?;
+    let identity = normalize_identity(&source)?;
+    let remote = ssh_transport(&source);
     let local_path = local_source_path(&args.source)?;
     if let Some(index) = existing_repo_index(&catalog, &identity) {
         if let Some(local_path) = local_path {
             let repo = &mut catalog.repos[index];
+            if repo.remote.is_none() {
+                repo.remote = remote;
+            }
             remember_path(repo, &local_path)?;
             let name = catalog::repo_name(repo).to_owned();
             catalog::save(&path, &catalog)?;
@@ -71,7 +76,7 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
         println!("  Local clone: {}", local_path.display());
         return Ok(());
     }
-    add_entry(&mut catalog, args, &identity);
+    add_entry(&mut catalog, args, &identity, remote);
     if let Some(local_path) = &local_path {
         remember_path(
             catalog.repos.last_mut().expect("entry was just added"),
@@ -111,11 +116,12 @@ pub fn new(cli: &Cli, args: &NewArgs) -> Result<()> {
     }
     git::initialize(&target)?;
     if args.github {
-        create_github_repository(&target, &identity, args.private)?;
+        create_github_repository(&target, &identity, !args.public)?;
     }
     add_entry_with(
         &mut catalog,
         &identity,
+        None,
         args.state,
         &args.tag,
         args.note.clone(),
@@ -190,7 +196,15 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
             println!("\nDry run: no files or catalog entries were changed.");
             return Ok(());
         }
-        finish_catalog_add(path, catalog, args, &identity, existing, false)?;
+        finish_catalog_add(
+            path,
+            catalog,
+            args,
+            &identity,
+            ssh_transport(&remote),
+            existing,
+            false,
+        )?;
         replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
         catalog::save(path, catalog)?;
         return Ok(());
@@ -252,7 +266,15 @@ fn migrate_and_add(cli: &Cli, args: &AddArgs, path: &Path, catalog: &mut Catalog
         )
     })?;
     println!("  {} Moved repository", ui::success_marker());
-    finish_catalog_add(path, catalog, args, &identity, existing, true)?;
+    finish_catalog_add(
+        path,
+        catalog,
+        args,
+        &identity,
+        ssh_transport(&remote),
+        existing,
+        true,
+    )?;
     replace_path(catalog_repo_mut(catalog, &identity)?, &source, &destination)?;
     catalog::save(path, catalog)
 }
@@ -357,16 +379,21 @@ fn finish_catalog_add(
     catalog: &mut Catalog,
     args: &AddArgs,
     identity: &str,
+    remote: Option<String>,
     existing: bool,
     moved: bool,
 ) -> Result<()> {
     if existing {
+        let repo = catalog_repo_mut(catalog, identity)?;
+        if repo.remote.is_none() {
+            repo.remote = remote;
+        }
         println!(
             "  {} Preserved existing catalog metadata",
             ui::success_marker()
         );
     } else {
-        add_entry(catalog, args, identity);
+        add_entry(catalog, args, identity, remote);
         catalog::save(path, catalog)?;
         println!("  {} Added to catalog", ui::success_marker());
     }
@@ -402,26 +429,41 @@ fn catalog_repo_mut<'a>(catalog: &'a mut Catalog, identity: &str) -> Result<&'a 
 }
 
 /// Add one catalog entry using the metadata supplied to `shu add`.
-fn add_entry(catalog: &mut Catalog, args: &AddArgs, identity: &str) {
-    add_entry_with(catalog, identity, args.state, &args.tag, args.note.clone());
+fn add_entry(catalog: &mut Catalog, args: &AddArgs, identity: &str, remote: Option<String>) {
+    add_entry_with(
+        catalog,
+        identity,
+        remote,
+        args.state,
+        &args.tag,
+        args.note.clone(),
+    );
 }
 
 /// Add a catalog entry from shared repository metadata.
 fn add_entry_with(
     catalog: &mut Catalog,
     identity: &str,
+    remote: Option<String>,
     state: Lifecycle,
     tags: &[String],
     note: Option<String>,
 ) {
     catalog.repos.push(Repo {
         source: identity.to_owned(),
+        remote,
         state,
         tags: catalog::unique(tags.to_vec()),
         note,
         paths: vec![],
         primary: None,
     });
+}
+
+/// Preserve only an explicit SSH transport; canonical identities use HTTPS.
+fn ssh_transport(source: &str) -> Option<String> {
+    let source = source.trim();
+    (source.starts_with("git@") || source.starts_with("ssh://")).then(|| source.to_owned())
 }
 
 /// Remember a clone path and choose it only when the current primary is invalid.
@@ -484,13 +526,13 @@ pub fn scan(cli: &Cli, args: &ScanArgs) -> Result<()> {
             serde_json::to_string_pretty(
                 &found
                     .iter()
-                    .map(|(path, identity)| serde_json::json!({"path": path, "identity": identity}))
+                    .map(|(path, identity, _)| serde_json::json!({"path": path, "identity": identity}))
                     .collect::<Vec<_>>()
             )?
         );
         Ok(())
     } else {
-        for (path, identity) in found {
+        for (path, identity, _) in found {
             let path = path.strip_prefix(&args.directory).unwrap_or(&path);
             print_scan_result(&identity, &path.display().to_string());
         }
@@ -554,7 +596,7 @@ pub fn forget(cli: &Cli, args: &SelectorArgs) -> Result<()> {
 }
 
 /// Find repositories with an `origin` remote outside hidden directory trees.
-pub(super) fn discover_repos(root: &Path) -> Result<Vec<(PathBuf, String)>> {
+pub(super) fn discover_repos(root: &Path) -> Result<Vec<(PathBuf, String, Option<String>)>> {
     if !root.exists() {
         bail!("scan directory does not exist: {}", root.display());
     }
@@ -578,7 +620,7 @@ pub(super) fn discover_repos(root: &Path) -> Result<Vec<(PathBuf, String)>> {
         if let Ok(remote) = git::output(entry.path(), ["remote", "get-url", "origin"])
             && let Ok(identity) = normalize_identity(&remote)
         {
-            found.push((entry.path().to_path_buf(), identity));
+            found.push((entry.path().to_path_buf(), identity, ssh_transport(&remote)));
         }
     }
     found.sort_by(|left, right| left.1.cmp(&right.1));
@@ -591,7 +633,7 @@ fn is_visible_scan_entry(entry: &DirEntry) -> bool {
 }
 
 /// Add only identities that are not already in the catalog.
-fn import_discovered(cli: &Cli, found: &[(PathBuf, String)]) -> Result<()> {
+fn import_discovered(cli: &Cli, found: &[(PathBuf, String, Option<String>)]) -> Result<()> {
     let (path, mut catalog) = catalog::load_or_initialize(cli)?;
     let mut known: HashSet<String> = catalog
         .repos
@@ -599,10 +641,11 @@ fn import_discovered(cli: &Cli, found: &[(PathBuf, String)]) -> Result<()> {
         .filter_map(|repo| normalize_identity(&repo.source).ok())
         .collect();
     let mut added = 0;
-    for (local_path, identity) in found {
+    for (local_path, identity, remote) in found {
         if known.insert(identity.clone()) {
             catalog.repos.push(Repo {
                 source: identity.clone(),
+                remote: remote.clone(),
                 state: Lifecycle::Active,
                 tags: vec![],
                 note: None,
@@ -612,6 +655,9 @@ fn import_discovered(cli: &Cli, found: &[(PathBuf, String)]) -> Result<()> {
             added += 1;
         }
         let repo = catalog_repo_mut(&mut catalog, identity)?;
+        if repo.remote.is_none() {
+            repo.remote = remote.clone();
+        }
         remember_path(repo, local_path)?;
     }
     catalog::save(&path, &catalog)?;

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -16,11 +16,11 @@ use crate::{
 /// Check the local Shu setup and report actionable failures.
 ///
 /// The default checks never access the network or modify repositories. Passing
-/// `--check-source` also resolves the remembered catalog source; Git-backed
-/// sources may refresh Shu's private catalog cache while doing so.
+/// `--check-source` also verifies that the remembered Git source is reachable.
 pub fn doctor(cli: &Cli, args: &DoctorArgs) -> Result<()> {
     let mut checks = Vec::new();
     checks.push(check_git());
+    checks.push(check_git_author()?);
 
     let path = catalog::catalog_path(cli)?;
     let loaded = catalog::load(cli);
@@ -153,6 +153,18 @@ fn check_git() -> Check {
     }
 }
 
+/// Confirm that Git can create the commits required by catalog sync.
+fn check_git_author() -> Result<Check> {
+    if git::has_author_identity()? {
+        Ok(Check::pass("Git author", "configured for catalog commits"))
+    } else {
+        Ok(Check::fail(
+            "Git author",
+            "missing user.name or user.email; configure both before `shu sync init`",
+        ))
+    }
+}
+
 /// Confirm that the catalog's root, or its nearest existing parent, is writable.
 fn check_root(catalog: &Catalog) -> Result<Check> {
     let root = root_path(catalog)?;
@@ -196,7 +208,7 @@ fn check_sync(catalog: Option<&Catalog>, check_source: bool) -> Result<Check> {
     check_sync_checkout(catalog.expect("sync has a catalog"), sync)
 }
 
-/// Confirm that the configured persistent checkout is ready without fetching.
+/// Confirm that the configured persistent checkout is clean and its remote is reachable.
 fn check_sync_checkout(catalog: &Catalog, sync: &Sync) -> Result<Check> {
     let checkout = root_path(catalog)?.join(crate::identity::normalize_identity(&sync.remote)?);
     if !git::is_repo(&checkout) {
@@ -215,9 +227,18 @@ fn check_sync_checkout(catalog: &Catalog, sync: &Sync) -> Result<Check> {
             format!("checkout has local changes: {}", checkout.display()),
         ));
     }
+    if let Err(error) = git::output(
+        &checkout,
+        ["ls-remote", "--exit-code", "origin", &sync.r#ref],
+    ) {
+        return Ok(Check::fail(
+            "catalog source",
+            format!("remote is not reachable on {}: {error}", sync.r#ref),
+        ));
+    }
     Ok(Check::pass(
         "catalog source",
-        format!("ready: {}", checkout.display()),
+        format!("reachable and clean: {}", checkout.display()),
     ))
 }
 

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -33,7 +33,7 @@ pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
         .collect::<Vec<_>>();
     if candidates.is_empty() {
         bail!(
-            "no catalogued repositories are available locally. Run `shu status` to see expected or recorded paths; use `shu add <repository>` to clone one, or run `shu add .` from an existing clone to record it"
+            "no catalogued repositories are available locally. Run `shu status` to see expected or recorded paths; use `shu ensure <repository>` to clone one, or run `shu add .` from an existing clone to record it"
         );
     }
 

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -104,7 +104,7 @@ pub fn sync(cli: &Cli, args: &SyncArgs) -> Result<()> {
 
 /// Safely commit and push the active catalog through its persistent Git checkout.
 fn sync_catalog(cli: &Cli) -> Result<()> {
-    let (catalog_file, catalog) = catalog::load(cli)?;
+    let (_, catalog) = catalog::load(cli)?;
     let sync = catalog.sync.clone().ok_or_else(|| {
         anyhow!("no Git catalog is configured; add [sync] to shu.toml before running `shu sync`")
     })?;
@@ -127,7 +127,7 @@ fn sync_catalog(cli: &Cli) -> Result<()> {
             filename.display()
         );
     }
-    let local_content = fs::read_to_string(&catalog_file)?;
+    let local_content = catalog::portable_contents(&catalog)?;
     if fs::read_to_string(&remote_catalog)? == local_content {
         println!("Catalog is already synced.");
         return Ok(());
@@ -198,7 +198,7 @@ fn sync_init(cli: &Cli, args: &SyncInitArgs) -> Result<()> {
     let mut synced_catalog = active_catalog;
     synced_catalog.sync = Some(sync.clone());
     let catalog_file = checkout.join(sync_filename(&sync)?);
-    catalog::save(&catalog_file, &synced_catalog)?;
+    catalog::save_portable(&catalog_file, &synced_catalog)?;
     git::output(&checkout, ["add", "--", "shu.toml"])?;
     git::output(&checkout, ["commit", "-m", "Initialize Shu catalog"])
         .context("could not commit the catalog; configure your Git author identity first")?;
@@ -296,14 +296,16 @@ fn activate_source(cli: &Cli, args: &RestoreArgs, source: &str) -> Result<()> {
     if loaded.version != 1 {
         bail!("unsupported catalog version {}", loaded.version);
     }
-    catalog::save(&catalog_path(cli)?, &loaded)?;
+    let (_, mut active) = catalog::load_or_initialize(cli)?;
+    catalog::merge_portable(&mut active, loaded)?;
+    catalog::save(&catalog_path(cli)?, &active)?;
     eprintln!("Using catalog from {source}");
     Ok(())
 }
 
 /// Clone or fast-forward the normal catalog checkout, then activate its TOML file.
 fn activate_git_source(cli: &Cli, args: &RestoreArgs, remote: &str) -> Result<()> {
-    let (_, active) = catalog::load_or_initialize(cli)?;
+    let (_, mut active) = catalog::load_or_initialize(cli)?;
     let file = args
         .file
         .as_deref()
@@ -343,7 +345,8 @@ fn activate_git_source(cli: &Cli, args: &RestoreArgs, remote: &str) -> Result<()
     {
         bail!("[sync] must match the repository URL, file, and ref passed to `shu restore`");
     }
-    catalog::save(&catalog_path(cli)?, &loaded)?;
+    catalog::merge_portable(&mut active, loaded)?;
+    catalog::save(&catalog_path(cli)?, &active)?;
     eprintln!("Using catalog from {remote}");
     Ok(())
 }
@@ -400,18 +403,22 @@ pub(crate) fn materialize(catalog: &mut Catalog, index: usize) -> Result<(PathBu
         let source = repo.remote.as_deref().unwrap_or(&repo.source);
         git::clone(source, &target)?;
         let target = absolute(&target)?;
-        remember_new_clone(&mut catalog.repos[index], &target);
+        remember_new_clone(catalog, index, &target)?;
         Ok((target, true))
     }
 }
 
 /// Add a just-created canonical clone to the one catalog file and prefer it if needed.
-fn remember_new_clone(repo: &mut crate::model::Repo, path: &std::path::Path) {
-    let replace_primary = repo
-        .primary_path()
+fn remember_new_clone(catalog: &mut Catalog, index: usize, path: &std::path::Path) -> Result<()> {
+    let replace_primary = locations::primary_path(catalog, &catalog.repos[index])?
         .is_none_or(|primary| !git::is_repo(&primary));
-    repo.add_path(path.to_path_buf());
-    if replace_primary {
-        repo.primary = Some(path.display().to_string());
+    let stored = locations::store_local_path(catalog, path)?;
+    let repo = &mut catalog.repos[index];
+    if !repo.paths.iter().any(|known| known == &stored) {
+        repo.paths.push(stored.clone());
     }
+    if replace_primary {
+        repo.primary = Some(stored);
+    }
+    Ok(())
 }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -167,6 +167,11 @@ fn sync_init(cli: &Cli, args: &SyncInitArgs) -> Result<()> {
     if args.github {
         super::catalog::ensure_github_ready()?;
     }
+    if !git::has_author_identity()? {
+        bail!(
+            "Git author identity is not configured; set user.name and user.email before `shu sync init`"
+        );
+    }
     let sync = Sync {
         remote: remote.clone(),
         file: "shu.toml".into(),
@@ -179,9 +184,14 @@ fn sync_init(cli: &Cli, args: &SyncInitArgs) -> Result<()> {
             checkout.display()
         );
     }
+    if !args.github && git::remote_has_heads(&remote)? {
+        bail!(
+            "catalog remote already has branches; use `shu restore {remote}` to activate it instead"
+        );
+    }
     git::initialize(&checkout)?;
     if args.github {
-        super::catalog::create_github_repository(&checkout, &identity, args.private)?;
+        super::catalog::create_github_repository(&checkout, &identity, !args.public)?;
     } else {
         git::output(&checkout, ["remote", "add", "origin", &remote])?;
     }
@@ -387,7 +397,8 @@ pub(crate) fn materialize(catalog: &mut Catalog, index: usize) -> Result<(PathBu
         );
     } else {
         eprintln!("↓ cloning {}", repo.source);
-        git::clone(&repo.source, &target)?;
+        let source = repo.remote.as_deref().unwrap_or(&repo.source);
+        git::clone(source, &target)?;
         let target = absolute(&target)?;
         remember_new_clone(&mut catalog.repos[index], &target);
         Ok((target, true))

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -67,7 +67,7 @@ fn observed_state(catalog: &Catalog, repo: &Repo) -> Result<String> {
             "present".into()
         });
     }
-    let remembered_exists = locations::remembered_paths(repo)?
+    let remembered_exists = locations::remembered_paths(catalog, repo)?
         .iter()
         .any(|path| path.exists());
     let managed = locations::managed_path(catalog, repo)?;
@@ -138,7 +138,7 @@ fn print_repository_status(catalog: &Catalog, repo: &Repo) -> Result<()> {
     println!("  {marker} {:<18} {observed}", repo_name(repo));
 
     if observed == "missing" {
-        for path in locations::remembered_paths(repo)? {
+        for path in locations::remembered_paths(catalog, repo)? {
             println!("    Recorded: {}", path.display());
         }
         let path = locations::managed_path(catalog, repo)?;
@@ -181,10 +181,11 @@ pub fn locations_command(cli: &Cli, args: &LocationsArgs) -> Result<()> {
             path
         };
         let name = catalog::repo_name(&catalog.repos[index]).to_owned();
+        let stored = locations::store_local_path(&catalog, &path)?;
         let is_recorded = catalog.repos[index]
             .paths
             .iter()
-            .any(|known| known == &path.display().to_string());
+            .any(|known| known == &stored);
         let is_managed = path == locations::managed_path(&catalog, &catalog.repos[index])?
             && crate::git::is_repo(&path);
         if !is_recorded && !is_managed {
@@ -195,16 +196,16 @@ pub fn locations_command(cli: &Cli, args: &LocationsArgs) -> Result<()> {
             );
         }
         if !is_recorded {
-            catalog.repos[index].add_path(path.clone());
+            catalog.repos[index].paths.push(stored.clone());
         }
-        catalog.repos[index].primary = Some(path.display().to_string());
+        catalog.repos[index].primary = Some(stored);
         catalog::save(&catalog_path, &catalog)?;
         println!("Preferred clone for {name}: {}", path.display());
     }
 
     let repo = &catalog.repos[index];
     let primary = locations::present_path(&catalog, repo)?;
-    let mut paths = locations::remembered_paths(repo)?;
+    let mut paths = locations::remembered_paths(&catalog, repo)?;
     let managed = locations::managed_path(&catalog, repo)?;
     if crate::git::is_repo(&managed) && !paths.iter().any(|path| path == &managed) {
         paths.push(managed);

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -252,7 +252,7 @@ fn print_uncatalogued(catalog: &Catalog) -> Result<()> {
     }
     let uncatalogued = discover_repos(&root)?
         .into_iter()
-        .filter(|(_, identity)| {
+        .filter(|(_, identity, _)| {
             !catalog
                 .repos
                 .iter()
@@ -261,7 +261,7 @@ fn print_uncatalogued(catalog: &Catalog) -> Result<()> {
         .collect::<Vec<_>>();
     if !uncatalogued.is_empty() {
         println!("\nUNCATALOGUED");
-        for (path, identity) in uncatalogued {
+        for (path, identity, _) in uncatalogued {
             println!("  {:<18} {}", identity, path.display());
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -112,13 +112,16 @@ pub fn git_output<const N: usize>(dir: &Path, args: [&str; N]) -> Result<String>
     output(dir, args)
 }
 
-/// Clone an identity into an empty canonical target path using HTTPS transport.
-pub fn clone(identity: &str, target: &Path) -> Result<()> {
+/// Clone a catalog source into an empty canonical target path.
+///
+/// Canonical identities use HTTPS. Explicit SSH remotes are preserved exactly
+/// as supplied so Git can use the user's configured SSH credentials.
+pub fn clone(source: &str, target: &Path) -> Result<()> {
     let parent = target
         .parent()
         .ok_or_else(|| anyhow!("target has no parent"))?;
     fs::create_dir_all(parent)?;
-    let remote = format!("https://{}.git", normalize_identity(identity)?);
+    let remote = clone_url(source)?;
     let output = Command::new("git")
         .args(["clone", "--", &remote])
         .arg(target)
@@ -128,10 +131,63 @@ pub fn clone(identity: &str, target: &Path) -> Result<()> {
     if !output.status.success() {
         let detail = String::from_utf8_lossy(&output.stderr).trim().to_owned();
         bail!(
-            "could not clone {identity}. Check your internet connection and Git access to this repository. Git said: {detail}"
+            "could not clone {source}. Check your internet connection and Git access to this repository. Git said: {detail}"
         );
     }
     Ok(())
+}
+
+/// Return the safe Git remote used to clone a catalog entry.
+fn clone_url(source: &str) -> Result<String> {
+    let source = source.trim();
+    if source.starts_with("git@") || source.starts_with("ssh://") {
+        return Ok(source.to_owned());
+    }
+    Ok(format!("https://{}.git", normalize_identity(source)?))
+}
+
+/// Return whether Git has an author identity available for commits.
+pub fn has_author_identity() -> Result<bool> {
+    if std::env::var_os("GIT_AUTHOR_NAME").is_some_and(|value| !value.is_empty())
+        && std::env::var_os("GIT_AUTHOR_EMAIL").is_some_and(|value| !value.is_empty())
+    {
+        return Ok(true);
+    }
+    Ok(git_config_value("user.name")?.is_some() && git_config_value("user.email")?.is_some())
+}
+
+/// Return one effective Git configuration value without requiring a repository.
+fn git_config_value(key: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["config", "--get", key])
+        .output()
+        .with_context(|| "could not run git; ensure Git is installed")?;
+    if output.status.success() {
+        return Ok(Some(String::from_utf8(output.stdout)?.trim().to_owned()));
+    }
+    if output.status.code() == Some(1) {
+        return Ok(None);
+    }
+    bail!(
+        "could not read Git configuration: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )
+}
+
+/// Return whether a remote already has branch heads.
+pub fn remote_has_heads(remote: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--heads", remote])
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| "could not run git ls-remote")?;
+    if !output.status.success() {
+        bail!(
+            "could not inspect remote {remote}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(!output.stdout.is_empty())
 }
 
 /// Clone a catalog remote with the user's existing Git credentials.

--- a/src/locations.rs
+++ b/src/locations.rs
@@ -4,14 +4,14 @@
 //! after `shu add .`. This module asks Git for linked worktrees when they are
 //! needed, without ever storing worktree state itself.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
 use crate::{
     git,
     model::{Catalog, Repo},
-    paths::{absolute, repo_path},
+    paths::{absolute, repo_path, root_path},
 };
 
 /// Return the canonical destination derived from the catalog root and identity.
@@ -20,17 +20,19 @@ pub fn managed_path(catalog: &Catalog, repo: &Repo) -> Result<PathBuf> {
 }
 
 /// Return every remembered clone path, including paths that have gone stale.
-pub fn remembered_paths(repo: &Repo) -> Result<Vec<PathBuf>> {
+pub fn remembered_paths(catalog: &Catalog, repo: &Repo) -> Result<Vec<PathBuf>> {
     repo.paths
         .iter()
-        .map(PathBuf::from)
-        .map(|path| absolute(&path))
+        .map(|path| resolve_local_path(catalog, path))
         .collect()
 }
 
 /// Return the explicitly selected clone path, including a stale path.
-pub fn primary_path(repo: &Repo) -> Result<Option<PathBuf>> {
-    repo.primary_path().map(|path| absolute(&path)).transpose()
+pub fn primary_path(catalog: &Catalog, repo: &Repo) -> Result<Option<PathBuf>> {
+    repo.primary
+        .as_deref()
+        .map(|path| resolve_local_path(catalog, path))
+        .transpose()
 }
 
 /// Return every valid full clone known for a repository on this machine.
@@ -39,7 +41,7 @@ pub fn primary_path(repo: &Repo) -> Result<Option<PathBuf>> {
 /// location is included when it is a valid repository even if it is absent
 /// from the catalog's `paths` list.
 pub fn present_paths(catalog: &Catalog, repo: &Repo) -> Result<Vec<PathBuf>> {
-    let mut paths = remembered_paths(repo)?
+    let mut paths = remembered_paths(catalog, repo)?
         .into_iter()
         .filter(|path| git::is_repo(path))
         .collect::<Vec<_>>();
@@ -55,12 +57,34 @@ pub fn present_paths(catalog: &Catalog, repo: &Repo) -> Result<Vec<PathBuf>> {
 /// An explicitly selected, valid primary clone wins. Otherwise Shu uses the
 /// first valid remembered path, then the canonical managed location.
 pub fn present_path(catalog: &Catalog, repo: &Repo) -> Result<Option<PathBuf>> {
-    if let Some(primary) = primary_path(repo)?
+    if let Some(primary) = primary_path(catalog, repo)?
         && git::is_repo(&primary)
     {
         return Ok(Some(primary));
     }
     Ok(present_paths(catalog, repo)?.into_iter().next())
+}
+
+/// Store a local path in its portable managed form when it resides below root.
+pub fn store_local_path(catalog: &Catalog, path: &Path) -> Result<String> {
+    let path = absolute(path)?;
+    let root = absolute(&root_path(catalog)?)?;
+    if let Ok(relative) = path.strip_prefix(root)
+        && !relative.as_os_str().is_empty()
+    {
+        return Ok(relative.display().to_string());
+    }
+    Ok(path.display().to_string())
+}
+
+/// Resolve a stored location relative to the local root, unless it is external.
+fn resolve_local_path(catalog: &Catalog, path: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        absolute(&path)
+    } else {
+        absolute(&root_path(catalog)?.join(path))
+    }
 }
 
 /// Return all present clone and linked-worktree paths for picker discovery.

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
 /// Parse arguments and dispatch the selected command implementation.
 fn run() -> Result<()> {
     let cli = Cli::parse();
+    validate_json(&cli)?;
     match &cli.command {
         None => commands::pick(&cli, &Default::default()),
         Some(Commands::Init) => commands::init(&cli),
@@ -73,5 +74,24 @@ fn run() -> Result<()> {
         Some(Commands::Forget(args)) => commands::forget(&cli, args),
         Some(Commands::Pick(args)) => commands::pick(&cli, args),
         Some(Commands::Shell(args)) => commands::shell(&args.command),
+    }
+}
+
+/// Reject JSON where the command has no stable machine-readable response.
+fn validate_json(cli: &Cli) -> Result<()> {
+    if !cli.json {
+        return Ok(());
+    }
+    let supported = match &cli.command {
+        Some(Commands::Doctor(_)) | Some(Commands::Status(_)) | Some(Commands::List(_)) => true,
+        Some(Commands::Scan(args)) => !args.add,
+        _ => false,
+    };
+    if supported {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "--json is supported by `list`, `status`, `doctor`, and `scan` without `--add`"
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,5 @@
 //! `shu.toml` types and machine-readable output structures.
 
-use std::path::{Path, PathBuf};
-
 use serde::{Deserialize, Serialize};
 
 use clap::ValueEnum;
@@ -67,43 +65,15 @@ pub struct Repo {
     /// Optional context explaining why the repository is retained.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
-    /// Full clone roots known for this repository on the current machine.
+    /// Clone paths known on the current machine.
     ///
-    /// Paths are intentionally stored in the single `shu.toml` catalog so the
-    /// user can inspect and edit all Shu state in one readable file. Missing
-    /// paths are harmless on another machine; Shu simply ignores them until a
-    /// valid local clone exists.
+    /// Managed paths are stored relative to the local catalog root. External
+    /// paths are absolute and deliberately excluded from the synced catalog.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub paths: Vec<String>,
     /// Preferred local clone path used when a command needs one destination.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary: Option<String>,
-}
-
-impl Repo {
-    /// Add a clone path once, preserving the order in which paths were added.
-    pub fn add_path(&mut self, path: PathBuf) {
-        let value = path.display().to_string();
-        if !self.paths.iter().any(|known| known == &value) {
-            self.paths.push(value);
-        }
-    }
-
-    /// Replace a moved clone path and make its destination the preferred clone.
-    pub fn replace_path(&mut self, source: &Path, destination: PathBuf) {
-        let source = source.display().to_string();
-        let destination = destination.display().to_string();
-        self.paths.retain(|known| known != &source);
-        if !self.paths.iter().any(|known| known == &destination) {
-            self.paths.push(destination.clone());
-        }
-        self.primary = Some(destination);
-    }
-
-    /// Return the explicit preferred clone path, if the catalog has one.
-    pub fn primary_path(&self) -> Option<PathBuf> {
-        self.primary.as_ref().map(PathBuf::from)
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -51,6 +51,13 @@ pub struct Catalog {
 pub struct Repo {
     /// Normalized `host/namespace/repository` identity.
     pub source: String,
+    /// Optional SSH transport preserved for cloning this repository.
+    ///
+    /// The canonical identity remains in [`Self::source`]. This field exists
+    /// only when the user explicitly added an SSH remote, so later restores do
+    /// not unexpectedly switch an SSH-only repository to HTTPS.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
     /// User-declared lifecycle state.
     #[serde(default = "default_state")]
     pub state: Lifecycle,

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -329,6 +329,69 @@ fn add_and_its_clone_alias_catalogue_and_clone_a_remote_repository() {
 }
 
 #[test]
+fn preserves_an_explicit_ssh_transport_for_later_restores() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_empty_catalog("library.toml");
+    let remote = "git@github.com:example-org/api.git";
+    let target = fixture.root.join("github.com/example-org/api");
+
+    fixture
+        .shu_ssh(["--catalog", catalog.to_str().unwrap(), "add", remote])
+        .assert_success();
+    assert!(target.join(".git").is_dir());
+    assert!(
+        fs::read_to_string(&catalog)
+            .unwrap()
+            .contains("remote = \"git@github.com:example-org/api.git\"")
+    );
+
+    fs::remove_dir_all(&target).unwrap();
+    fixture
+        .shu_ssh([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "ensure",
+            "api",
+            "--path-only",
+        ])
+        .assert_success();
+    assert!(target.join(".git").is_dir());
+}
+
+#[test]
+fn rejects_json_for_commands_without_a_stable_json_contract() {
+    let fixture = Fixture::new();
+    let output = fixture.shu(["--json", "ensure", "api"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8(output.stderr).unwrap().contains(
+            "--json is supported by `list`, `status`, `doctor`, and `scan` without `--add`"
+        )
+    );
+}
+
+#[test]
+fn sync_init_refuses_a_remote_that_already_has_branches() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_empty_catalog("library.toml");
+    let output = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "sync",
+        "init",
+        IDENTITY,
+    ]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("catalog remote already has branches")
+    );
+}
+
+#[test]
 fn scan_skips_hidden_directories_and_groups_each_result() {
     let fixture = Fixture::new();
     let scan_root = fixture.temp.path().join("scan-root");
@@ -984,6 +1047,21 @@ impl Fixture {
             .env("GIT_CONFIG_COUNT", "1")
             .env("GIT_CONFIG_KEY_0", key)
             .env("GIT_CONFIG_VALUE_0", "https://github.com/example-org/")
+            .env("GIT_AUTHOR_NAME", "Shu Test")
+            .env("GIT_AUTHOR_EMAIL", "shu@example.invalid")
+            .env("GIT_COMMITTER_NAME", "Shu Test")
+            .env("GIT_COMMITTER_EMAIL", "shu@example.invalid")
+            .output()
+            .unwrap()
+    }
+
+    fn shu_ssh<const N: usize>(&self, args: [&str; N]) -> Output {
+        let key = format!("url.{}.insteadOf", self.rewrite_prefix);
+        Command::new(env!("CARGO_BIN_EXE_shu"))
+            .args(args)
+            .env("GIT_CONFIG_COUNT", "1")
+            .env("GIT_CONFIG_KEY_0", key)
+            .env("GIT_CONFIG_VALUE_0", "git@github.com:example-org/")
             .env("GIT_AUTHOR_NAME", "Shu Test")
             .env("GIT_AUTHOR_EMAIL", "shu@example.invalid")
             .env("GIT_COMMITTER_NAME", "Shu Test")

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -273,11 +273,75 @@ fn initializes_and_publishes_a_dedicated_catalog_checkout() {
     assert!(active.contains("[sync]"));
     assert!(active.contains("remote = \"https://github.com/example-org/catalog.git\""));
     let remote_catalog = run_git_output(&fixture.catalog_remote, ["show", "main:shu.toml"]);
-    assert_eq!(remote_catalog, active);
+    assert!(!remote_catalog.contains("root ="));
+    assert!(!remote_catalog.contains("paths ="));
+    assert!(!remote_catalog.contains("primary ="));
+    assert!(remote_catalog.contains("[sync]"));
     assert!(
         !active.contains("source = \"github.com/example-org/catalog\""),
         "the catalog repository must not become a picker entry"
     );
+}
+
+#[test]
+fn sync_keeps_external_locations_local_and_restores_managed_paths_per_machine() {
+    let fixture = Fixture::new();
+    let first = fixture.write_empty_catalog("first.toml");
+    let remote = "https://github.com/example-org/catalog.git";
+
+    fixture
+        .shu(["--catalog", first.to_str().unwrap(), "sync", "init", remote])
+        .assert_success();
+    fixture
+        .shu([
+            "--catalog",
+            first.to_str().unwrap(),
+            "add",
+            fixture.seed.to_str().unwrap(),
+        ])
+        .assert_success();
+    let first_content = fs::read_to_string(&first)
+        .unwrap()
+        .replace("remote = \"git@github.com:example-org/api.git\"\n", "");
+    fs::write(&first, &first_content).unwrap();
+    fixture
+        .shu(["--catalog", first.to_str().unwrap(), "sync"])
+        .assert_success();
+
+    assert!(first_content.contains(fixture.seed.to_string_lossy().as_ref()));
+    let synced = run_git_output(&fixture.catalog_remote, ["show", "main:shu.toml"]);
+    assert!(synced.contains("source = \"github.com/example-org/api\""));
+    assert!(!synced.contains("root ="));
+    assert!(!synced.contains(fixture.seed.to_string_lossy().as_ref()));
+    assert!(!synced.contains("paths ="));
+
+    let second_root = fixture.temp.path().join("second-library");
+    let second = fixture.temp.path().join("second.toml");
+    fs::write(
+        &second,
+        format!("version = 1\nroot = \"{}\"\n", second_root.display()),
+    )
+    .unwrap();
+    fixture
+        .shu([
+            "--catalog",
+            second.to_str().unwrap(),
+            "--yes",
+            "restore",
+            remote,
+        ])
+        .assert_success();
+
+    let expected = second_root.join("github.com/example-org/api");
+    assert!(expected.join(".git").is_dir());
+    let second_content = fs::read_to_string(&second).unwrap();
+    assert!(second_content.contains(&format!("root = \"{}\"", second_root.display())));
+    let second_catalog: toml::Value = toml::from_str(&second_content).unwrap();
+    assert_eq!(
+        second_catalog["repos"][0]["paths"].as_array().unwrap()[0].as_str(),
+        Some("github.com/example-org/api")
+    );
+    assert!(!second_content.contains(fixture.seed.to_string_lossy().as_ref()));
 }
 
 #[test]

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -308,18 +308,24 @@ fn sync_keeps_external_locations_local_and_restores_managed_paths_per_machine() 
         .shu(["--catalog", first.to_str().unwrap(), "sync"])
         .assert_success();
 
-    assert!(first_content.contains(fixture.seed.to_string_lossy().as_ref()));
+    let first_catalog: toml::Value = toml::from_str(&first_content).unwrap();
+    assert_same_path(
+        first_catalog["repos"][0]["paths"][0].as_str().unwrap(),
+        &fixture.seed,
+    );
     let synced = run_git_output(&fixture.catalog_remote, ["show", "main:shu.toml"]);
     assert!(synced.contains("source = \"github.com/example-org/api\""));
     assert!(!synced.contains("root ="));
-    assert!(!synced.contains(fixture.seed.to_string_lossy().as_ref()));
     assert!(!synced.contains("paths ="));
 
     let second_root = fixture.temp.path().join("second-library");
     let second = fixture.temp.path().join("second.toml");
     fs::write(
         &second,
-        format!("version = 1\nroot = \"{}\"\n", second_root.display()),
+        format!(
+            "version = 1\nroot = \"{}\"\n",
+            second_root.to_string_lossy().replace('\\', "/")
+        ),
     )
     .unwrap();
     fixture
@@ -335,13 +341,12 @@ fn sync_keeps_external_locations_local_and_restores_managed_paths_per_machine() 
     let expected = second_root.join("github.com/example-org/api");
     assert!(expected.join(".git").is_dir());
     let second_content = fs::read_to_string(&second).unwrap();
-    assert!(second_content.contains(&format!("root = \"{}\"", second_root.display())));
     let second_catalog: toml::Value = toml::from_str(&second_content).unwrap();
+    assert_same_path(second_catalog["root"].as_str().unwrap(), &second_root);
     assert_eq!(
         second_catalog["repos"][0]["paths"].as_array().unwrap()[0].as_str(),
         Some("github.com/example-org/api")
     );
-    assert!(!second_content.contains(fixture.seed.to_string_lossy().as_ref()));
 }
 
 #[test]
@@ -526,6 +531,63 @@ fn scan_skips_hidden_directories_and_groups_each_result() {
     assert!(!output.contains("shallow"));
     assert!(output.contains("github.com/example-org/parent\n  parent"));
     assert!(!output.contains("vendor/api"));
+}
+
+#[test]
+fn restores_and_selects_from_a_large_catalog_deterministically() {
+    const REPOSITORY_COUNT: usize = 32;
+
+    let fixture = Fixture::new();
+    let catalog = fixture.temp.path().join("large-library.toml");
+    let mut content = format!(
+        "version = 1\nroot = \"{}\"\n",
+        fixture.root.to_string_lossy().replace('\\', "/")
+    );
+
+    for index in 0..REPOSITORY_COUNT {
+        let name = format!("stress-{index:02}");
+        let remote = fixture.remote.parent().unwrap().join(format!("{name}.git"));
+        run_git(
+            fixture.temp.path(),
+            ["clone", "--bare", fixture.remote.to_str().unwrap()],
+            Some(&remote),
+        );
+        content.push_str(&format!(
+            "\n[[repos]]\nsource = \"github.com/example-org/{name}\"\nstate = \"active\"\n"
+        ));
+    }
+    fs::write(&catalog, content).unwrap();
+
+    fixture
+        .shu(["--catalog", catalog.to_str().unwrap(), "--yes", "restore"])
+        .assert_success();
+
+    let listed = fixture.shu(["--catalog", catalog.to_str().unwrap(), "--json", "list"]);
+    listed.assert_success();
+    let repositories = serde_json::from_slice::<Value>(&listed.stdout).unwrap()["repositories"]
+        .as_array()
+        .unwrap()
+        .to_owned();
+    assert_eq!(repositories.len(), REPOSITORY_COUNT);
+    assert!(
+        repositories
+            .iter()
+            .all(|repo| repo["observed_state"] == "present")
+    );
+
+    let selected = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--filter",
+        "stress-31",
+        "--path-only",
+    ]);
+    selected.assert_success();
+    assert_same_path(
+        String::from_utf8(selected.stdout).unwrap().trim(),
+        &fixture.root.join("github.com/example-org/stress-31"),
+    );
 }
 
 #[test]

--- a/tests/docker/e2e.sh
+++ b/tests/docker/e2e.sh
@@ -48,6 +48,23 @@ shu --catalog "$workspace/shu.toml" locations api --primary "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" ensure api --path-only)" = "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$workspace/seed"
 
+# A larger catalog exercises repeated clone, catalog, list, and picker paths
+# in the same clean container. Each identity has its own local bare remote so
+# the normal Git URL rewrite and clone code are used for every repository.
+stress_catalog="$workspace/stress.toml"
+printf 'version = 1\nroot = "%s/stress-library"\n' "$workspace" > "$stress_catalog"
+index=0
+while [ "$index" -lt 16 ]; do
+    name="stress-$index"
+    git clone --bare "$workspace/remotes/api.git" "$workspace/remotes/$name.git" >/dev/null
+    printf '\n[[repos]]\nsource = "github.com/example-org/%s"\nstate = "active"\n' "$name" >> "$stress_catalog"
+    index=$((index + 1))
+done
+shu --catalog "$stress_catalog" --yes restore
+test "$(shu --catalog "$stress_catalog" --json list | grep -c '"observed_state": "present"')" = 16
+test "$(shu --catalog "$stress_catalog" pick --filter stress-15 --path-only)" = \
+  "$workspace/stress-library/github.com/example-org/stress-15"
+
 # Sync publishes repository metadata only. Root-relative managed paths and
 # arbitrary external clone paths remain local to this machine.
 GIT_AUTHOR_NAME='Shu Test' GIT_AUTHOR_EMAIL='shu@example.invalid' \

--- a/tests/docker/e2e.sh
+++ b/tests/docker/e2e.sh
@@ -6,6 +6,7 @@ trap 'rm -rf "$workspace"' EXIT
 
 mkdir -p "$workspace/remotes"
 git init --bare "$workspace/remotes/api.git" >/dev/null
+git init --bare "$workspace/remotes/catalog.git" >/dev/null
 git init "$workspace/seed" >/dev/null
 printf 'fixture\n' > "$workspace/seed/README.md"
 git -C "$workspace/seed" add README.md
@@ -32,7 +33,8 @@ shu --catalog "$workspace/shu.toml" --yes restore
 path="$(shu --catalog "$workspace/shu.toml" ensure api --path-only)"
 test "$path" = "$workspace/library/github.com/example-org/api"
 test -d "$path/.git"
-shu --catalog "$workspace/shu.toml" doctor | grep -q '^✓ catalog:'
+GIT_AUTHOR_NAME='Shu Test' GIT_AUTHOR_EMAIL='shu@example.invalid' \
+  shu --catalog "$workspace/shu.toml" doctor | grep -q '^✓ catalog:'
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$path"
 shu --catalog "$workspace/shu.toml" --json list | grep -q '"observed_state": "present"'
 
@@ -45,6 +47,26 @@ GIT_CONFIG_COUNT=0 shu --catalog "$workspace/shu.toml" add "$workspace/seed"
 shu --catalog "$workspace/shu.toml" locations api --primary "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" ensure api --path-only)" = "$workspace/seed"
 test "$(shu --catalog "$workspace/shu.toml" pick --filter api --path-only)" = "$workspace/seed"
+
+# Sync publishes repository metadata only. Root-relative managed paths and
+# arbitrary external clone paths remain local to this machine.
+GIT_AUTHOR_NAME='Shu Test' GIT_AUTHOR_EMAIL='shu@example.invalid' \
+GIT_COMMITTER_NAME='Shu Test' GIT_COMMITTER_EMAIL='shu@example.invalid' \
+  shu --catalog "$workspace/shu.toml" sync init github.com/example-org/catalog
+synced="$(git --git-dir "$workspace/remotes/catalog.git" show main:shu.toml)"
+printf '%s\n' "$synced" | grep -q 'source = "github.com/example-org/api"'
+! printf '%s\n' "$synced" | grep -q 'root ='
+! printf '%s\n' "$synced" | grep -q "$workspace/seed"
+! printf '%s\n' "$synced" | grep -q 'paths ='
+
+cat > "$workspace/second.toml" <<EOF
+version = 1
+root = "$workspace/second-library"
+EOF
+shu --catalog "$workspace/second.toml" --yes restore github.com/example-org/catalog
+test -d "$workspace/second-library/github.com/example-org/api/.git"
+grep -q '"github.com/example-org/api"' "$workspace/second.toml"
+! grep -q "$workspace/seed" "$workspace/second.toml"
 
 # Shell setup is persistent and idempotent. Use an explicit file in the
 # container so this checks the same setup path without changing a real shell
@@ -66,8 +88,13 @@ test -d "$workspace/library/github.com/example-org/migrated/.git"
 # release payload. The fake curl command gives the installer the same
 # command-line contract it has when downloading a GitHub Release.
 mkdir -p "$workspace/release-assets" "$workspace/fake-bin" "$workspace/installed"
-cp /usr/local/bin/shu "$workspace/release-assets/shu-x86_64-unknown-linux-musl"
-(cd "$workspace/release-assets" && sha256sum shu-x86_64-unknown-linux-musl > SHA256SUMS)
+case "$(uname -m)" in
+    x86_64) target='x86_64-unknown-linux-musl' ;;
+    aarch64|arm64) target='aarch64-unknown-linux-musl' ;;
+    *) echo "unsupported Linux architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+cp /usr/local/bin/shu "$workspace/release-assets/shu-$target"
+(cd "$workspace/release-assets" && sha256sum "shu-$target" > SHA256SUMS)
 cat > "$workspace/fake-bin/curl" <<'EOF'
 #!/bin/sh
 set -eu


### PR DESCRIPTION
Brings the v0.1.14/v0.1.15 releases and README update onto main, then adds repeated Docker and CLI stress coverage. Also fixes the Windows TOML-path assertion exposed by CI.