### PR TITLE
Release Shu 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ and releases use [Semantic Versioning](https://semver.org/).
   coverage, repeated CLI and Docker end-to-end runs, and semantic Windows path
   assertions.
 
+## [0.1.16] - 2026-07-28
+
+### Added
+
+- A shared terminal presentation layer with cyan action cues, semantic
+  success/warning/error outcomes, aligned detail rows, and concise recovery
+  guidance.
+- A redesigned repository picker that distinguishes the preferred checkout,
+  separate checkouts, and Git worktrees without storing new catalog metadata.
+- Honest upgrade download progress based on received bytes and response size
+  when available.
+- `scripts/design-proposal.sh`, a runnable preview of Shu's terminal design
+  language and command surfaces.
+
+### Changed
+
+- Repository creation, restore, sync, upgrade, status, doctor, shell setup,
+  and selection output now share the same human-facing presentation patterns.
+- Worktree branch details are derived once while building picker candidates,
+  keeping redraws responsive.
+
 ## [0.1.15] - 2026-07-28
 
 ### Changed
@@ -270,7 +291,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.15...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.16...HEAD
+[0.1.16]: https://github.com/wiedymi/shu/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/wiedymi/shu/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/wiedymi/shu/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/wiedymi/shu/compare/v0.1.12...v0.1.13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/scripts/design-proposal.sh
+++ b/scripts/design-proposal.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env sh
+# A runnable, read-only preview of Shu's proposed terminal design language.
+# It does not call Shu, read configuration, or make network requests.
+
+set -eu
+
+color=1
+animate=1
+
+usage() {
+    printf '%s\n' "Usage: scripts/design-proposal.sh [--no-color] [--static]"
+    printf '%s\n' "  --no-color  Render without terminal color."
+    printf '%s\n' "  --static    Show representative progress frames without animation."
+}
+
+for argument in "$@"; do
+    case "$argument" in
+        --no-color) color=0 ;;
+        --static) animate=0 ;;
+        --help|-h) usage; exit 0 ;;
+        *) printf 'Unknown option: %s\n' "$argument" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if ! test -t 1; then
+    color=0
+    animate=0
+fi
+
+if test "${TERM:-dumb}" = dumb; then
+    color=0
+fi
+
+style() {
+    if test "$color" -eq 1; then
+        case "$1" in
+            sgr0) printf '\033[0m' ;;
+            bold) printf '\033[1m' ;;
+            dim) printf '\033[2m' ;;
+            setaf) printf '\033[%sm' "$2" ;;
+            setab) printf '\033[%sm' "$2" ;;
+        esac
+    fi
+}
+
+reset() { style sgr0; }
+muted() { style dim; }
+accent() { style setaf 36; style bold; }
+good() { style setaf 32; style bold; }
+warn() { style setaf 33; style bold; }
+bad() { style setaf 31; style bold; }
+title() { style bold; }
+
+# A single-cell input anchor. It is the only colored surface in the picker;
+# the solid block keeps no-color output legible.
+input_cell() {
+    if test "$color" -eq 1; then
+        style setab 46; printf ' '; reset
+    else
+        printf '█'
+    fi
+}
+
+line() {
+    printf '%s\n' '────────────────────────────────────────────────────────────────────────'
+}
+
+heading() {
+    printf '\n'
+    accent; printf 'shu'; reset; muted; printf ' / '; reset; title; printf '%s\n' "$1"; reset
+    line
+}
+
+label() {
+    muted; printf '%-12s' "$1"; reset
+}
+
+heading 'Terminal design proposal'
+printf '%s\n' 'A quiet, information-dense interface for people, while scripts retain exact output.'
+printf '%s\n' 'This preview is illustrative only: it performs no Shu operation and no network activity.'
+
+heading '1. Design contract'
+printf '%s\n' '  • One visual grammar: action → live work → durable result → next useful command.'
+printf '%s\n' '  • Meaning comes before decoration: labels, verbs, paths, and states are always textual.'
+printf '%s\n' '  • Styling is additive and only used on an interactive terminal; no style carries meaning alone.'
+printf '%s\n' '  • stdout remains clean for values and --json. Human narration and live progress use stderr.'
+printf '%s\n' '  • Progress is honest: indeterminate work says what is happening; byte work shows bytes when known.'
+printf '%s\n' '  • No permanent success noise. A completed operation gets one compact summary.'
+printf '%s\n' '  • Picking preserves terminal context: a compact, bottom-aligned filter—not a separate full-screen app.'
+
+heading '2. Shared primitives'
+printf '  '; good; printf '✓'; reset; printf '  completed or already true\n'
+printf '  '; accent; printf '→'; reset; printf '  starting a meaningful step\n'
+printf '  '; accent; printf '…'; reset; printf '  work in progress when total work is unknown\n'
+printf '  '; warn; printf '!'; reset; printf '  attention needed; the operation can continue or explains the choice\n'
+printf '  '; bad; printf '×'; reset; printf '  operation failed; show cause and the immediate recovery command\n'
+printf '\n'
+printf '  '; label 'result'; printf 'github.com/wiedymi/shu\n'
+printf '  '; label 'location'; printf '/Users/wiedy/Code/github.com/wiedymi/shu\n'
+printf '  '; label 'next'; printf 'shu status\n'
+
+heading '3. Operations: truthful work feedback'
+printf '%s\n' 'TTY-only work feedback is quiet and factual: a named spinner before a size is known, then real received bytes.'
+printf '\n'
+muted; printf 'Installing '; reset; title; printf 'shu'; reset; muted; printf '  version '; reset; printf '0.1.16\n'
+
+if test "$animate" -eq 1; then
+    for frame in '◐' '◓' '◑' '◒'; do
+        printf '\r  '
+        accent; printf '%s ' "$frame"; reset
+        printf 'Finding release asset'
+        sleep 0.12
+    done
+    printf '\r  '
+    good; printf '✓ '; reset
+    printf 'Found shu-darwin-arm64.tar.gz                              \n'
+else
+    printf '  '; accent; printf '… '; reset; printf 'Finding release asset\n'
+    printf '  '; good; printf '✓ '; reset; printf 'Found shu-darwin-arm64.tar.gz\n'
+fi
+printf '  '; accent; printf '→ '; reset; printf 'Downloading shu-darwin-arm64.tar.gz\n'
+printf '  '; accent; printf '[███████████······] '; reset; printf '4.2 MiB / 6.8 MiB  62%%\n'
+printf '  '; good; printf '✓ '; reset; printf 'Installed shu 0.1.16\n'
+printf '  '; label 'location'; printf '~/.local/bin/shu\n'
+printf '  '; label 'next'; printf 'shu --version\n'
+
+heading '4. Fuzzy picker: focused selection'
+printf '%s\n' 'A compact bottom prompt keeps terminal context visible. Repository identity leads; the local path confirms the choice.'
+printf '\n'
+accent; printf 'Pick a repository\n'; reset
+printf '\n'
+input_cell; printf ' '; muted; printf 'Search repositories\n'; reset
+printf '\n'
+accent; printf '› '; reset; title; printf 'wiedymi/shu'; reset
+printf '  '; accent; printf '◆'; reset
+printf '\n  '; muted; printf '~/Code/github.com/wiedymi/shu\n'; reset
+printf '\n  '; title; printf 'wiedymi/api'; reset
+printf '  '; accent; printf '⎇ '; reset; muted; printf 'feature/auth'; reset
+printf '\n  '; muted; printf '~/Code/github.com/wiedymi/api\n'; reset
+printf '\n  '; title; printf 'acme/api-docs'; reset
+printf '  '; accent; printf '◇'; reset
+printf '\n  '; muted; printf '~/Code/github.com/acme/api-docs\n'; reset
+printf '\n'; accent; printf '◆'; reset; muted; printf ' primary   '; reset
+accent; printf '◇'; reset; muted; printf ' checkout   '; reset
+accent; printf '⎇'; reset; muted; printf ' worktree\n'; reset
+printf '\n'; muted; printf '↑↓ navigate  ·  / filter  ·  enter open  ·  esc cancel\n'; reset
+printf '\n'
+muted; printf 'After /\n'; reset
+printf '\n'
+accent; printf 'Find a repository\n'; reset
+printf '\n'
+input_cell; printf ' api\n\n'
+accent; printf '› '; reset; title; printf 'wiedymi/api'; reset
+printf '  '; accent; printf '⎇ '; reset; muted; printf 'feature/auth'; reset
+printf '\n  '; muted; printf '~/Code/github.com/wiedymi/api\n'; reset
+printf '\n  '; title; printf 'acme/api'; reset
+printf '  '; accent; printf '◇'; reset
+printf '\n  '; muted; printf '~/Code/github.com/acme/api\n'; reset
+printf '\n  '; title; printf 'acme/api-docs'; reset
+printf '  '; accent; printf '◆'; reset
+printf '\n  '; muted; printf '~/Code/github.com/acme/api-docs\n'; reset
+printf '\n'; muted; printf '3 matches  ·  esc cancel\n'; reset
+
+heading '5. Status, confirmations, and errors'
+printf '%s\n' 'Status groups by outcome, confirmations name the consequence, and errors pair a clear cause with one recovery.'
+printf '\n'
+accent; printf 'shu'; reset; printf '  Library status'; muted; printf '                                      12 repositories'; reset
+printf '\n\n'
+good; printf '✓ '; reset; printf 'Ready'; muted; printf '  10'; reset
+printf '\n  github.com/wiedymi/shu'; muted; printf '                    /Users/wiedy/Code/github.com/wiedymi/shu'; reset
+printf '\n\n'
+warn; printf '! '; reset; printf 'Needs restore'; muted; printf '  2'; reset
+printf '\n  github.com/wiedymi/archive'; muted; printf '                expected at ~/Code/github.com/wiedymi/archive'; reset
+printf '\n  '; label 'next'; printf 'shu ensure github.com/wiedymi/archive\n'
+printf '\n'
+warn; printf '! '; reset; printf 'Move repository into Shu library?\n'
+printf '  '; label 'from'; printf '/tmp/shu\n'
+printf '  '; label 'to'; printf '~/Code/github.com/wiedymi/shu\n'
+printf '  '; label 'effect'; printf 'moves the clean clone; Git history and files are unchanged\n'
+printf '  Continue? [y/N] '
+printf '\n\n'
+bad; printf '× '; reset; printf 'Could not clone github.com/wiedymi/shu\n'
+printf '  '; label 'cause'; printf 'authentication to github.com was rejected\n'
+printf '  '; label 'next'; printf 'gh auth login, then rerun shu ensure github.com/wiedymi/shu\n'
+
+heading '6. Everyday command surfaces'
+printf '%s\n' 'Commands that create, publish, update, or explain themselves use the same compact action → result grammar.'
+printf '\n'
+accent; printf 'New repository\n'; reset
+muted; printf '  shu new github.com/wiedymi/notes --github --private\n'; reset
+printf '  '; accent; printf '→ '; reset; printf 'Create local repository\n'
+printf '  '; accent; printf '→ '; reset; printf 'Create private GitHub repository\n'
+printf '  '; good; printf '✓ '; reset; printf 'Created wiedymi/notes\n'
+printf '  '; label 'location'; printf '~/Code/github.com/wiedymi/notes\n'
+printf '  '; label 'next'; printf 'cd ~/Code/github.com/wiedymi/notes\n'
+printf '\n'
+accent; printf 'Set up catalog sync\n'; reset
+muted; printf '  shu sync init github.com/wiedymi/repository-library --github --private\n'; reset
+printf '  '; accent; printf '→ '; reset; printf 'Create catalog checkout\n'
+printf '  '; accent; printf '→ '; reset; printf 'Publish shu.toml to github.com/wiedymi/repository-library\n'
+printf '  '; good; printf '✓ '; reset; printf 'Catalog sync is ready\n'
+printf '  '; label 'checkout'; printf '~/Code/github.com/wiedymi/repository-library\n'
+printf '  '; label 'next'; printf 'shu sync\n'
+printf '\n'
+accent; printf 'Sync catalog\n'; reset
+muted; printf '  shu sync\n'; reset
+printf '  '; accent; printf '… '; reset; printf 'Checking github.com/wiedymi/repository-library\n'
+printf '  '; good; printf '✓ '; reset; printf 'Published shu.toml\n'
+printf '  '; label 'remote'; printf 'github.com/wiedymi/repository-library\n'
+printf '\n'
+accent; printf 'Upgrade\n'; reset
+muted; printf '  shu upgrade\n'; reset
+printf '  '; label 'version'; printf '0.1.15 → 0.1.16\n'
+printf '  '; accent; printf '… '; reset; printf 'Downloading shu-darwin-arm64.tar.gz\n'
+printf '  '; accent; printf '[███████████······] '; reset; printf '4.2 MiB / 6.8 MiB  62%%\n'
+printf '  '; good; printf '✓ '; reset; printf 'Updated shu to 0.1.16\n'
+printf '\n'
+accent; printf 'Version\n'; reset
+muted; printf '  shu --version\n'; reset
+printf '  shu 0.1.16\n'
+printf '\n'
+accent; printf 'Help\n'; reset
+muted; printf '  shu --help\n'; reset
+printf '  shu — declarative repository library\n\n'
+printf '  Usage: shu [OPTIONS] [COMMAND]\n\n'
+printf '  Everyday commands\n'
+printf '    add <repository>      Record a repository and clone it when needed\n'
+printf '    new <repository>      Create a local repository, optionally on GitHub\n'
+printf '    pick                  Find and open a local repository\n'
+printf '    status                See what is ready, missing, or needs attention\n'
+printf '    sync                  Publish the active catalog\n'
+printf '    restore <source>      Load a saved catalog and restore missing clones\n'
+printf '    upgrade               Install the latest verified Shu release\n\n'
+muted; printf '  Run '; reset; printf 'shu <command> --help'; muted; printf ' for options and examples.\n'; reset
+
+heading '7. Implementation boundary'
+printf '%s\n' 'Apply this in a dedicated UI layer, not as formatting scattered through command logic:'
+printf '%s\n' '  • Output mode is explicit: Machine (JSON/path), Human (persistent lines), or Interactive (picker/progress).'
+printf '%s\n' '  • A single Progress state enum covers Pending, Indeterminate, Sized { done, total }, Complete, and Failed.'
+printf '%s\n' '  • Commands report operation facts; the UI layer owns stream selection, color, layout, and cleanup.'
+printf '%s\n' '  • Progress receives bounded byte counts only from the download stream—never invented percentages or timings.'
+printf '%s\n' '  • The picker writes only to stderr, leaves stdout as the selected path, and uses a bottom-aligned bounded region.'
+printf '%s\n' '  • Picker rows pair a repository identity with its local path; the location role removes ambiguity without becoming stored metadata.'
+printf '%s\n' '  • A derived location role is a closed set: primary checkout, separate checkout, or worktree (with branch when Git reports one).'
+
+heading '8. Proposed rollout'
+printf '%s\n' '  1. Establish output modes and shared renderer with snapshot tests for non-TTY output.'
+printf '%s\n' '  2. Adopt it for restore, ensure, add, upgrade, sync, and scan—the operations that can take noticeable time.'
+printf '%s\n' '  3. Replace the picker with a bounded, fzf-like renderer after terminal-size, resize, Unicode-width, and stdout-capture behavior are covered.'
+printf '%s\n' '  4. Bring catalog, status, doctor, and errors onto the same result grammar; preserve --json exactly.'
+printf '\n'
+good; printf '✓ '; reset; printf 'End of proposal. Run with --static for deterministic review output.\n'

--- a/src/commands/catalog.rs
+++ b/src/commands/catalog.rs
@@ -41,7 +41,8 @@ pub fn init(cli: &Cli) -> Result<()> {
             sync: None,
         },
     )?;
-    println!("Initialized Shu catalog at {}", path.display());
+    ui::success("Initialized Shu catalog");
+    ui::detail("location", path.display());
     Ok(())
 }
 
@@ -63,8 +64,8 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
             remember_path(&mut catalog, index, &local_path)?;
             let name = catalog::repo_name(&catalog.repos[index]).to_owned();
             catalog::save(&path, &catalog)?;
-            println!("Already catalogued {name}");
-            println!("  Local clone: {}", local_path.display());
+            ui::success(format!("Already catalogued {name}"));
+            ui::detail("Local clone:", local_path.display());
             return Ok(());
         }
         let name = catalog::repo_name(&catalog.repos[index]).to_owned();
@@ -72,8 +73,8 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
         if cloned {
             catalog::save(&path, &catalog)?;
         }
-        println!("Already catalogued {name}");
-        println!("  Local clone: {}", local_path.display());
+        ui::success(format!("Already catalogued {name}"));
+        ui::detail("Local clone:", local_path.display());
         return Ok(());
     }
     add_entry(&mut catalog, args, &identity, remote);
@@ -87,8 +88,8 @@ pub fn add(cli: &Cli, args: &AddArgs) -> Result<()> {
         None => restore::materialize(&mut catalog, index)?.0,
     };
     catalog::save(&path, &catalog)?;
-    println!("Added {identity}");
-    println!("  Local clone: {}", local_path.display());
+    ui::success(format!("Added {identity}"));
+    ui::detail("location", local_path.display());
     Ok(())
 }
 
@@ -112,8 +113,11 @@ pub fn new(cli: &Cli, args: &NewArgs) -> Result<()> {
             target.display()
         );
     }
+    ui::heading("New repository");
+    ui::action("Create local repository");
     git::initialize(&target)?;
     if args.github {
+        ui::working("Creating GitHub repository");
         create_github_repository(&target, &identity, !args.public)?;
     }
     add_entry_with(
@@ -127,10 +131,10 @@ pub fn new(cli: &Cli, args: &NewArgs) -> Result<()> {
     let index = catalog.repos.len() - 1;
     remember_path(&mut catalog, index, &target)?;
     catalog::save(&catalog_path, &catalog)?;
-    println!("Created {identity}");
-    println!("  Local repository: {}", target.display());
+    ui::success(format!("Created {identity}"));
+    ui::detail("location", target.display());
     if args.github {
-        println!("  GitHub repository: created");
+        ui::detail("GitHub", "repository created");
     }
     Ok(())
 }
@@ -513,11 +517,11 @@ pub fn edit(cli: &Cli, args: &EditArgs) -> Result<()> {
     let note = repo.note.clone();
     catalog::save(&path, &catalog)?;
 
-    println!("Updated {name}");
-    println!("  State: {state}");
+    ui::success(format!("Updated {name}"));
+    ui::detail("state", state);
     match note {
-        Some(note) => println!("  Note:  {note}"),
-        None => println!("  Note:  none"),
+        Some(note) => ui::detail("note", note),
+        None => ui::detail("note", "none"),
     }
     Ok(())
 }
@@ -585,7 +589,7 @@ pub fn change_state(cli: &Cli, selector: &str, state: Lifecycle) -> Result<()> {
     catalog.repos[index].state = state;
     let name = catalog::repo_name(&catalog.repos[index]).to_owned();
     catalog::save(&path, &catalog)?;
-    println!("Set {name} to {state}");
+    ui::success(format!("Set {name} to {state}"));
     Ok(())
 }
 
@@ -595,10 +599,11 @@ pub fn forget(cli: &Cli, args: &SelectorArgs) -> Result<()> {
     let index = catalog::select_index(&catalog, &args.selector)?;
     let removed = catalog.repos.remove(index);
     catalog::save(&path, &catalog)?;
-    println!(
-        "Removed {} from the catalog. Local repository was not deleted.",
+    ui::success(format!(
+        "Removed {} from the catalog",
         normalize_identity(&removed.source)?
-    );
+    ));
+    ui::detail("local", "repository was not deleted");
     Ok(())
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -11,6 +11,7 @@ use crate::{
     git,
     model::{Catalog, Sync},
     paths::root_path,
+    ui,
 };
 
 /// Check the local Shu setup and report actionable failures.
@@ -258,7 +259,12 @@ fn render(cli: &Cli, checks: &[Check]) -> Result<()> {
             CheckStatus::Fail => "✗",
             CheckStatus::Skip => "-",
         };
-        println!("{marker} {}: {}", check.name, check.detail);
+        let line = format!("{}: {}", check.name, check.detail);
+        match check.status {
+            CheckStatus::Pass => ui::success(line),
+            CheckStatus::Fail => println!("{} {line}", ui::failure_marker()),
+            CheckStatus::Skip => println!("{marker} {line}"),
+        }
     }
     Ok(())
 }

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -11,14 +11,14 @@ use crossterm::{
     cursor::{Hide, MoveTo, Show},
     event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
     execute,
-    style::{Attribute, SetAttribute},
+    style::{Color, Stylize},
     terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 use crate::{
     catalog,
     cli::{Cli, PickArgs},
-    locations,
+    git, locations,
     model::Repo,
 };
 
@@ -47,11 +47,8 @@ pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
         if args.path_only {
             println!("{}", selected.path.display());
         } else {
-            println!(
-                "Selected {}\n{}",
-                selected.identity,
-                selected.path.display()
-            );
+            crate::ui::success(format!("Selected {}", selected.identity));
+            crate::ui::detail("location", selected.path.display());
         }
     }
     Ok(())
@@ -61,21 +58,24 @@ pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
 struct Candidate {
     identity: String,
     location: LocationKind,
+    branch: Option<String>,
     path: PathBuf,
 }
 
-/// A location is either an independent clone or a Git-linked worktree.
+/// A picker location is derived from catalog preference and Git worktree state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LocationKind {
-    Clone,
+    Primary,
+    Checkout,
     Worktree,
 }
 
 impl LocationKind {
-    fn label(self) -> &'static str {
+    fn symbol(self) -> &'static str {
         match self {
-            Self::Clone => "clone",
-            Self::Worktree => "worktree",
+            Self::Primary => "◆",
+            Self::Checkout => "◇",
+            Self::Worktree => "⎇",
         }
     }
 }
@@ -83,17 +83,28 @@ impl LocationKind {
 /// Convert each present clone and Git worktree into a searchable picker candidate.
 fn candidates(catalog: &crate::model::Catalog, repo: &Repo) -> Result<Vec<Candidate>> {
     let clones = locations::present_paths(catalog, repo)?;
+    let primary = locations::present_path(catalog, repo)?;
     locations::pickable_paths(catalog, repo).map(|paths| {
         paths
             .into_iter()
-            .map(|path| Candidate {
-                identity: repo.source.clone(),
-                location: if clones.contains(&path) {
-                    LocationKind::Clone
+            .map(|path| {
+                let location = if primary.as_ref().is_some_and(|primary| primary == &path) {
+                    LocationKind::Primary
+                } else if clones.contains(&path) {
+                    LocationKind::Checkout
                 } else {
                     LocationKind::Worktree
-                },
-                path,
+                };
+                let branch = (location == LocationKind::Worktree)
+                    .then(|| git::output(&path, ["branch", "--show-current"]).ok())
+                    .flatten()
+                    .filter(|branch| !branch.is_empty());
+                Candidate {
+                    identity: repo.source.clone(),
+                    location,
+                    branch,
+                    path,
+                }
             })
             .collect()
     })
@@ -226,10 +237,10 @@ impl PickerTerminal {
         Ok(Self { stderr })
     }
 
-    /// Redraw the result list above a single bottom-aligned search prompt.
+    /// Redraw Shu's focused repository picker.
     fn render(&mut self, query: &str, candidates: &[Candidate], selected: usize) -> Result<()> {
         let (width, height) = terminal_size()?;
-        let visible = usize::from(height.saturating_sub(1));
+        let visible = usize::from(height.saturating_sub(6)) / 3;
         execute!(self.stderr, MoveTo(0, 0), Clear(ClearType::All))?;
         let first_visible = selected.saturating_sub(visible.saturating_sub(1));
         let visible_candidates = candidates
@@ -237,48 +248,72 @@ impl PickerTerminal {
             .skip(first_visible)
             .take(visible)
             .collect::<Vec<_>>();
-        let first_row = height
-            .saturating_sub(1)
-            .saturating_sub(visible_candidates.len() as u16);
-        for (index, candidate) in visible_candidates.into_iter().enumerate() {
-            let row = format!(
-                "[{}] {}",
-                candidate.location.label(),
-                candidate.path.display()
-            );
-            execute!(
-                self.stderr,
-                MoveTo(0, first_row + index as u16),
-                Clear(ClearType::CurrentLine)
-            )?;
-            if first_visible + index == selected {
-                execute!(self.stderr, SetAttribute(Attribute::Reverse))?;
-                write!(
-                    self.stderr,
-                    "› {}",
-                    fit_to_width(&row, width.saturating_sub(2))
-                )?;
-                execute!(self.stderr, SetAttribute(Attribute::Reset))?;
-            } else {
-                write!(
-                    self.stderr,
-                    "  {}",
-                    fit_to_width(&row, width.saturating_sub(2))
-                )?;
-            }
-        }
-        execute!(
-            self.stderr,
-            MoveTo(0, height.saturating_sub(1)),
-            Clear(ClearType::CurrentLine),
-            SetAttribute(Attribute::Reverse)
-        )?;
         write!(
             self.stderr,
-            "› {}",
-            tail_to_width(query, width.saturating_sub(2))
+            "{}\n\n",
+            "Pick a repository".with(Color::Cyan).bold()
         )?;
-        execute!(self.stderr, SetAttribute(Attribute::Reset))?;
+        write!(self.stderr, "{} ", " ".on(Color::Cyan))?;
+        if query.is_empty() {
+            write!(
+                self.stderr,
+                "{}\n\n",
+                "Search repositories".with(Color::DarkGrey)
+            )?;
+        } else {
+            write!(self.stderr, "{query}\n\n")?;
+        }
+        for (index, candidate) in visible_candidates.into_iter().enumerate() {
+            let row = &candidate.identity;
+            if first_visible + index == selected {
+                writeln!(
+                    self.stderr,
+                    "{} {}  {}",
+                    "›".with(Color::Cyan).bold(),
+                    fit_to_width(row, width.saturating_sub(8)).bold(),
+                    candidate.location.symbol().with(Color::Cyan).bold(),
+                )?;
+            } else {
+                writeln!(
+                    self.stderr,
+                    "  {}  {}",
+                    fit_to_width(row, width.saturating_sub(8)),
+                    candidate.location.symbol().with(Color::Cyan),
+                )?;
+            }
+            let branch = candidate
+                .branch
+                .as_ref()
+                .map(|branch| format!("  {branch}"))
+                .unwrap_or_default();
+            write!(
+                self.stderr,
+                "  {}{}\n\n",
+                fit_to_width(
+                    &candidate.path.display().to_string(),
+                    width.saturating_sub(4)
+                )
+                .with(Color::DarkGrey),
+                branch.with(Color::DarkGrey),
+            )?;
+        }
+        let count = candidates.len();
+        writeln!(
+            self.stderr,
+            "{} {}   {} {}   {} {}",
+            "◆".with(Color::Cyan),
+            "primary".with(Color::DarkGrey),
+            "◇".with(Color::Cyan),
+            "checkout".with(Color::DarkGrey),
+            "⎇".with(Color::Cyan),
+            "worktree".with(Color::DarkGrey),
+        )?;
+        writeln!(
+            self.stderr,
+            "{}  ·  {}",
+            format!("{count} matches").with(Color::DarkGrey),
+            "↑↓ navigate  / filter  enter open  esc cancel".with(Color::DarkGrey),
+        )?;
         self.stderr.flush()?;
         Ok(())
     }
@@ -308,25 +343,6 @@ fn fit_to_width(text: &str, width: u16) -> String {
     format!("{}…", text.chars().take(width - 1).collect::<String>())
 }
 
-/// Show the active end of a long query, where newly typed text appears.
-fn tail_to_width(text: &str, width: u16) -> String {
-    let width = usize::from(width);
-    let length = text.chars().count();
-    if length <= width {
-        return text.to_owned();
-    }
-    if width == 0 {
-        return String::new();
-    }
-    if width == 1 {
-        return "…".to_owned();
-    }
-    format!(
-        "…{}",
-        text.chars().skip(length - width + 1).collect::<String>()
-    )
-}
-
 impl Drop for PickerTerminal {
     fn drop(&mut self) {
         let _ = execute!(self.stderr, Show, LeaveAlternateScreen);
@@ -349,14 +365,14 @@ mod tests {
     }
 
     #[test]
-    fn picker_rows_stay_on_one_line_and_keep_the_active_query_visible() {
+    fn picker_rows_stay_on_one_line() {
         assert_eq!(fit_to_width("/repositories/example", 8), "/reposi…");
-        assert_eq!(tail_to_width("repository", 5), "…tory");
     }
 
     #[test]
-    fn locations_have_clear_distinct_labels() {
-        assert_eq!(LocationKind::Clone.label(), "clone");
-        assert_eq!(LocationKind::Worktree.label(), "worktree");
+    fn locations_have_clear_distinct_symbols() {
+        assert_eq!(LocationKind::Primary.symbol(), "◆");
+        assert_eq!(LocationKind::Checkout.symbol(), "◇");
+        assert_eq!(LocationKind::Worktree.symbol(), "⎇");
     }
 }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -17,7 +17,7 @@ use crate::{
     git, locations,
     model::{Catalog, Sync},
     paths::{absolute, repo_path, root_path},
-    sources,
+    sources, ui,
 };
 
 /// Restore a catalog source, if supplied, and clone all selected missing entries.
@@ -41,7 +41,7 @@ pub fn restore(cli: &Cli, args: &RestoreArgs) -> Result<()> {
         .map(|(index, _)| index)
         .collect::<Vec<_>>();
     if !confirm_restore(cli, args, repo_indices.len())? {
-        println!("No changes made.");
+        ui::warning("No changes made.");
         return Ok(());
     }
     fs::create_dir_all(root_path(&catalog)?)?;
@@ -52,7 +52,7 @@ pub fn restore(cli: &Cli, args: &RestoreArgs) -> Result<()> {
         match restore_one(&mut catalog, index) {
             Ok(wrote_path) => changed |= wrote_path,
             Err(error) => {
-                eprintln!("! {source}: {error:#}");
+                ui::warning_to_stderr(format!("{source}: {error:#}"));
                 failures += 1;
             }
         }
@@ -109,6 +109,8 @@ fn sync_catalog(cli: &Cli) -> Result<()> {
         anyhow!("no Git catalog is configured; add [sync] to shu.toml before running `shu sync`")
     })?;
     let checkout = sync_checkout(&catalog, &sync)?;
+    ui::heading("Sync catalog");
+    ui::working(format!("Checking {}", sync.remote));
     verify_checkout(&checkout, &sync)?;
     let filename = sync_filename(&sync)?;
     git::output(&checkout, ["fetch", "origin", &sync.r#ref])?;
@@ -129,9 +131,10 @@ fn sync_catalog(cli: &Cli) -> Result<()> {
     }
     let local_content = catalog::portable_contents(&catalog)?;
     if fs::read_to_string(&remote_catalog)? == local_content {
-        println!("Catalog is already synced.");
+        ui::success("Catalog is already synced.");
         return Ok(());
     }
+    ui::action("Publish shu.toml");
     fs::write(&remote_catalog, local_content)?;
     let filename = filename
         .to_str()
@@ -148,7 +151,8 @@ fn sync_catalog(cli: &Cli) -> Result<()> {
         );
     }
     git::output(&checkout, ["push", "origin", &sync.r#ref])?;
-    println!("Synced catalog to {}.", sync.remote);
+    ui::success("Published shu.toml");
+    ui::detail("remote", sync.remote);
     Ok(())
 }
 
@@ -189,8 +193,11 @@ fn sync_init(cli: &Cli, args: &SyncInitArgs) -> Result<()> {
             "catalog remote already has branches; use `shu restore {remote}` to activate it instead"
         );
     }
+    ui::heading("Set up catalog sync");
+    ui::action("Create catalog checkout");
     git::initialize(&checkout)?;
     if args.github {
+        ui::working("Creating private GitHub catalog repository");
         super::catalog::create_github_repository(&checkout, &identity, !args.public)?;
     } else {
         git::output(&checkout, ["remote", "add", "origin", &remote])?;
@@ -202,12 +209,13 @@ fn sync_init(cli: &Cli, args: &SyncInitArgs) -> Result<()> {
     git::output(&checkout, ["add", "--", "shu.toml"])?;
     git::output(&checkout, ["commit", "-m", "Initialize Shu catalog"])
         .context("could not commit the catalog; configure your Git author identity first")?;
+    ui::working(format!("Publishing shu.toml to {remote}"));
     git::output(&checkout, ["push", "-u", "origin", "main"]).context(
         "could not publish the catalog; confirm the remote exists and Git access is configured",
     )?;
     catalog::save(&active_path, &synced_catalog)?;
-    println!("Initialized catalog sync at {remote}.");
-    println!("  Checkout: {}", checkout.display());
+    ui::success("Catalog sync is ready");
+    ui::detail("checkout", checkout.display());
     Ok(())
 }
 
@@ -267,7 +275,8 @@ pub fn ensure(cli: &Cli, args: &EnsureArgs) -> Result<()> {
     if args.path_only {
         println!("{}", target.display());
     } else {
-        println!("Ensured {name} at {}", target.display());
+        ui::success(format!("Ensured {name}"));
+        ui::detail("location", target.display());
     }
     Ok(())
 }
@@ -299,7 +308,7 @@ fn activate_source(cli: &Cli, args: &RestoreArgs, source: &str) -> Result<()> {
     let (_, mut active) = catalog::load_or_initialize(cli)?;
     catalog::merge_portable(&mut active, loaded)?;
     catalog::save(&catalog_path(cli)?, &active)?;
-    eprintln!("Using catalog from {source}");
+    ui::working(format!("Using catalog from {source}"));
     Ok(())
 }
 
@@ -347,7 +356,7 @@ fn activate_git_source(cli: &Cli, args: &RestoreArgs, remote: &str) -> Result<()
     }
     catalog::merge_portable(&mut active, loaded)?;
     catalog::save(&catalog_path(cli)?, &active)?;
-    eprintln!("Using catalog from {remote}");
+    ui::working(format!("Using catalog from {remote}"));
     Ok(())
 }
 
@@ -378,7 +387,8 @@ fn restore_one(catalog: &mut Catalog, index: usize) -> Result<bool> {
     let name = repo_name(&catalog.repos[index]).to_owned();
     let (path, cloned) = materialize(catalog, index)?;
     if !cloned {
-        println!("✓ {} already present at {}", name, path.display());
+        ui::success(format!("{name} already present"));
+        ui::detail("location", path.display());
     }
     Ok(cloned)
 }
@@ -399,7 +409,7 @@ pub(crate) fn materialize(catalog: &mut Catalog, index: usize) -> Result<(PathBu
             target.display()
         );
     } else {
-        eprintln!("↓ cloning {}", repo.source);
+        ui::working(format!("Cloning {}", repo.source));
         let source = repo.remote.as_deref().unwrap_or(&repo.source);
         git::clone(source, &target)?;
         let target = absolute(&target)?;

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -8,7 +8,10 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 
-use crate::cli::{Shell, ShellCommands, ShellInitArgs};
+use crate::{
+    cli::{Shell, ShellCommands, ShellInitArgs},
+    ui,
+};
 
 const BEGIN_MARKER: &str = "# >>> shu shell integration >>>";
 const END_MARKER: &str = "# <<< shu shell integration <<<";
@@ -33,13 +36,22 @@ fn init(args: &ShellInitArgs) -> Result<()> {
         None => default_profile(args.shell)?,
     };
     install(&path, script)?;
-    println!("Installed Shu navigation for {}.", shell_name(args.shell));
-    println!("  Startup file: {}", path.display());
-    println!(
-        "  Open a new {} session, then run `shu` to pick a repository.",
+    ui::success(format!(
+        "Installed Shu navigation for {}",
         shell_name(args.shell)
+    ));
+    ui::detail("startup", path.display());
+    ui::detail(
+        "next",
+        format!(
+            "open a new {} session, then run `shu`",
+            shell_name(args.shell)
+        ),
     );
-    println!("  This command cannot change the shell that is already running.");
+    ui::detail(
+        "note",
+        "this command cannot change the shell already running",
+    );
     Ok(())
 }
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -2,14 +2,14 @@
 
 use std::{
     env, fs,
-    io::{self, IsTerminal, Read, Write},
+    io::Read,
     path::{Path, PathBuf},
 };
 
 #[cfg(windows)]
 use std::process::Command;
 
-use crate::{cli::UpgradeArgs, hash::sha256_hex, http};
+use crate::{cli::UpgradeArgs, hash::sha256_hex, http, ui};
 use anyhow::{Context, Result, anyhow, bail};
 
 const RELEASE_REPOSITORY: &str = "wiedymi/shu";
@@ -26,20 +26,20 @@ pub fn upgrade(args: &UpgradeArgs) -> Result<()> {
     let current = env::current_exe().context("could not determine Shu executable path")?;
     let asset = format!("shu-{target}{}", executable_extension());
     let base = release_base(args.version.as_deref());
-    eprintln!("\nShu upgrade\n");
-    eprintln!("  Platform: {target}");
-    eprintln!("  Release: {}", args.version.as_deref().unwrap_or("latest"));
+    ui::heading("Upgrade");
+    ui::detail("platform", target);
+    ui::detail("release", args.version.as_deref().unwrap_or("latest"));
     let client = http::agent();
-    eprintln!("  Downloading SHA256SUMS");
+    ui::working("Downloading SHA256SUMS");
     let manifest = get_text(&client, &format!("{base}/SHA256SUMS"))?;
-    eprintln!("  Reading release manifest");
+    ui::working("Reading release manifest");
     let expected = checksum_for(&manifest, &asset)?;
-    eprintln!("  Downloading {asset}");
+    ui::working(format!("Downloading {asset}"));
     let binary = get_bytes(&client, &format!("{base}/{asset}"), &asset)?;
-    eprintln!("  Verifying checksum");
+    ui::working("Verifying checksum");
     verify_checksum(&binary, &expected, &asset)?;
 
-    eprintln!("  Installing");
+    ui::action("Install verified release");
     let staged = staged_path(&current)?;
     fs::write(&staged, binary)
         .with_context(|| format!("could not write downloaded binary {}", staged.display()))?;
@@ -50,14 +50,14 @@ pub fn upgrade(args: &UpgradeArgs) -> Result<()> {
     #[cfg(not(windows))]
     replace_now(&current, &staged)?;
 
-    println!("✓ Shu upgrade downloaded successfully.");
+    ui::success("Downloaded verified Shu release");
     #[cfg(windows)]
-    println!(
-        "It will replace {} after this process exits.",
-        current.display()
+    ui::detail(
+        "location",
+        format!("replaces {} after this process exits", current.display()),
     );
     #[cfg(not(windows))]
-    println!("Updated {}.", current.display());
+    ui::detail("location", current.display());
     Ok(())
 }
 
@@ -143,8 +143,6 @@ struct DownloadProgress<'a> {
     downloaded: u64,
     /// Number of bytes shown in the previous update.
     last_rendered: u64,
-    /// Whether standard error supports an in-place progress line.
-    interactive: bool,
 }
 
 impl<'a> DownloadProgress<'a> {
@@ -155,14 +153,13 @@ impl<'a> DownloadProgress<'a> {
             total,
             downloaded: 0,
             last_rendered: 0,
-            interactive: io::stderr().is_terminal(),
         }
     }
 
     /// Record downloaded bytes and refresh an interactive progress line when useful.
     fn advance(&mut self, count: u64) -> Result<()> {
         self.downloaded += count;
-        if self.interactive && self.downloaded - self.last_rendered >= PROGRESS_INTERVAL_BYTES {
+        if self.downloaded - self.last_rendered >= PROGRESS_INTERVAL_BYTES {
             self.render()?;
         }
         Ok(())
@@ -170,53 +167,20 @@ impl<'a> DownloadProgress<'a> {
 
     /// Complete the progress display with a final, stable line.
     fn finish(&mut self) -> Result<()> {
-        if self.interactive {
-            self.render()?;
-            eprintln!();
-        } else {
-            eprintln!(
-                "  Downloaded {} ({})",
-                self.asset,
-                human_size(self.downloaded)
-            );
-        }
+        self.render()?;
+        eprintln!();
         Ok(())
     }
 
     /// Rewrite one interactive line with the transferred byte count and percentage.
     fn render(&mut self) -> Result<()> {
-        let detail = match self.total {
-            Some(total) if total > 0 => format!(
-                "{} / {} ({}%)",
-                human_size(self.downloaded),
-                human_size(total),
-                self.downloaded.saturating_mul(100) / total
-            ),
-            _ => human_size(self.downloaded),
-        };
-        eprint!("\r  Downloading {}: {detail}", self.asset);
-        io::stderr().flush()?;
+        ui::render_download_progress(self.asset, self.downloaded, self.total)?;
         self.last_rendered = self.downloaded;
         Ok(())
     }
 }
 
 /// Format a byte count for a short human-facing progress message.
-fn human_size(bytes: u64) -> String {
-    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
-    let mut value = bytes as f64;
-    let mut unit = 0;
-    while value >= 1024.0 && unit < UNITS.len() - 1 {
-        value /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{bytes} {}", UNITS[unit])
-    } else {
-        format!("{value:.1} {}", UNITS[unit])
-    }
-}
-
 /// Extract one hexadecimal checksum from a standard `SHA256SUMS` manifest.
 fn checksum_for(manifest: &str, asset: &str) -> Result<String> {
     manifest
@@ -313,8 +277,8 @@ mod tests {
 
     #[test]
     fn formats_download_sizes_for_humans() {
-        assert_eq!(human_size(512), "512 B");
-        assert_eq!(human_size(1536), "1.5 KiB");
-        assert_eq!(human_size(5 * 1024 * 1024), "5.0 MiB");
+        assert_eq!(ui::human_size(512), "512 B");
+        assert_eq!(ui::human_size(1536), "1.5 KiB");
+        assert_eq!(ui::human_size(5 * 1024 * 1024), "5.0 MiB");
     }
 }

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -27,8 +27,10 @@ pub fn status(cli: &Cli, filter: &FilterArgs) -> Result<()> {
     if cli.json {
         return print_json(cli, &catalog, repos);
     }
-    println!("Catalog: {}", catalog_path(cli)?.display());
-    println!("Root:    {}\n", root_path(&catalog)?.display());
+    ui::heading("Library status");
+    ui::detail("catalog", catalog_path(cli)?.display());
+    ui::detail("root", root_path(&catalog)?.display());
+    println!();
     print_grouped_status(&catalog, repos)?;
     print_uncatalogued(&catalog)
 }
@@ -119,11 +121,14 @@ fn print_grouped_status(catalog: &Catalog, repos: Vec<&Repo>) -> Result<()> {
     for repo in repos {
         if current != Some(repo.state) {
             current = Some(repo.state);
-            println!("{}", repo.state.to_string().to_uppercase());
+            println!("{}", ui::accent(repo.state.to_string().to_uppercase()));
         }
         print_repository_status(catalog, repo)?;
     }
-    println!("\nEdit metadata: shu edit <repository> --state <state> --note <text>");
+    ui::detail(
+        "next",
+        "shu edit <repository> --state <state> --note <text>",
+    );
     Ok(())
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,53 +1,150 @@
-//! Small, consistent terminal presentation helpers.
+//! Shared human-facing terminal components.
 //!
-//! Shu keeps command output plain enough to read in logs and scripts while
-//! adding color only when the receiving stream is an interactive terminal.
+//! Commands own facts and machine-readable output. This module owns the small,
+//! terminal-aware visual language used for people: cyan actions, semantic
+//! outcomes, dim supporting detail, and honest progress.
 
-use std::io::{IsTerminal, stderr, stdout};
+use std::io::{IsTerminal, Write, stderr, stdout};
 
 use anyhow::Error;
 use crossterm::style::{Color, Stylize};
 
-/// Render a concise error with its immediate underlying cause when available.
+/// Render a concise error with its immediate underlying cause and recovery hint.
 pub fn render_error(error: &Error) {
-    eprintln!(
-        "{} {error}",
-        label("error", Color::Red, stderr().is_terminal())
-    );
+    eprintln!("{} {error}", failure_marker());
     let mut causes = error.chain();
     let _ = causes.next();
     if let Some(cause) = causes.next()
         && cause.to_string() != error.to_string()
     {
-        eprintln!(
-            "  {} {cause}",
-            label("cause", Color::DarkGrey, stderr().is_terminal())
-        );
+        detail_to_stderr("cause", cause);
     }
+    detail_to_stderr("help", "Run `shu --help` for a command overview.");
+}
+
+/// Print a compact command heading.
+pub fn heading(title: impl std::fmt::Display) {
+    println!("{} {title}", accent("shu"));
+}
+
+/// Print one operation that is starting or may take time.
+pub fn action(message: impl std::fmt::Display) {
+    println!("{} {message}", action_marker());
+}
+
+/// Print an operation that is currently waiting on external work.
+pub fn working(message: impl std::fmt::Display) {
+    eprintln!("{} {message}", working_marker());
+}
+
+/// Print a completed outcome.
+pub fn success(message: impl std::fmt::Display) {
+    println!("{} {message}", success_marker());
+}
+
+/// Print a warning or attention outcome.
+pub fn warning(message: impl std::fmt::Display) {
+    println!("{} {message}", warning_marker());
+}
+
+/// Print a warning on standard error when it accompanies a recoverable failure.
+pub fn warning_to_stderr(message: impl std::fmt::Display) {
     eprintln!(
-        "  {} Run `shu --help` for a command overview.",
-        label("help", Color::Cyan, stderr().is_terminal())
+        "{} {message}",
+        tone("!", Color::Yellow, stderr().is_terminal())
     );
+}
+
+/// Print one dim, aligned supporting value on standard output.
+pub fn detail(label: &str, value: impl std::fmt::Display) {
+    println!("  {} {value}", dim(format!("{label:<10}")));
+}
+
+/// Print one dim, aligned supporting value on standard error.
+pub fn detail_to_stderr(label: &str, value: impl std::fmt::Display) {
+    eprintln!("  {} {value}", dim(format!("{label:<10}")));
 }
 
 /// Return a success marker suitable for human-readable command output.
 pub fn success_marker() -> String {
-    label("✓", Color::Green, stdout().is_terminal())
+    tone("✓", Color::Green, stdout().is_terminal())
 }
 
 /// Return an attention marker suitable for human-readable command output.
 pub fn warning_marker() -> String {
-    label("!", Color::Yellow, stdout().is_terminal())
+    tone("!", Color::Yellow, stdout().is_terminal())
 }
 
 /// Return a failure marker suitable for human-readable command output.
 pub fn failure_marker() -> String {
-    label("✗", Color::Red, stdout().is_terminal())
+    tone("×", Color::Red, stderr().is_terminal())
 }
 
-/// Add terminal color only when the output can render it correctly.
-fn label(text: &str, color: Color, color_enabled: bool) -> String {
-    if color_enabled {
+/// Return the cyan action marker used for commands and picker structure.
+pub fn action_marker() -> String {
+    tone("→", Color::Cyan, stdout().is_terminal())
+}
+
+/// Return the cyan working marker used when a total is not known yet.
+pub fn working_marker() -> String {
+    tone("…", Color::Cyan, stderr().is_terminal())
+}
+
+/// Apply the terminal's dim attribute only when it can be rendered.
+pub fn dim(value: impl std::fmt::Display) -> String {
+    let value = value.to_string();
+    if stdout().is_terminal() {
+        format!("{}", value.with(Color::DarkGrey))
+    } else {
+        value
+    }
+}
+
+/// Apply Shu's cyan accent only when it can be rendered.
+pub fn accent(value: impl std::fmt::Display) -> String {
+    tone(&value.to_string(), Color::Cyan, stdout().is_terminal())
+}
+
+/// Draw byte-based download progress without inventing totals or percentages.
+pub fn render_download_progress(
+    asset: &str,
+    downloaded: u64,
+    total: Option<u64>,
+) -> std::io::Result<()> {
+    if !stderr().is_terminal() {
+        return Ok(());
+    }
+    let detail = match total.filter(|total| *total > 0) {
+        Some(total) => format!(
+            "{} / {}  {}%",
+            human_size(downloaded),
+            human_size(total),
+            downloaded.saturating_mul(100) / total
+        ),
+        None => human_size(downloaded),
+    };
+    eprint!("\r{} Downloading {asset}  {detail}", working_marker());
+    stderr().flush()
+}
+
+/// Format a byte count for compact human-facing progress.
+pub fn human_size(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn tone(text: &str, color: Color, enabled: bool) -> String {
+    if enabled {
         format!("{}", text.with(color).bold())
     } else {
         text.to_owned()


### PR DESCRIPTION
## Release 0.1.16\n\n- Refine terminal output with shared presentation components\n- Redesign the repository picker with derived checkout topology\n- Add real upgrade download progress and the runnable design proposal\n\nValidated locally with the full release gate: formatting, locked tests, Clippy, rustdoc, Docker build, and installer E2E.