### PR TITLE
Fix terminal picker and upgrade feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and releases use [Semantic Versioning](https://semver.org/).
   coverage, repeated CLI and Docker end-to-end runs, and semantic Windows path
   assertions.
 
+## [0.1.17] - 2026-07-28
+
+### Fixed
+
+- Keep every picker row at column zero in raw terminals, preventing long
+  repository identities and paths from drifting into adjacent rows.
+
+### Changed
+
+- `shu upgrade` now resolves and shows the exact target release version before
+  downloading, and uses a single cyan, byte-backed progress bar throughout the
+  binary transfer.
+
 ## [0.1.16] - 2026-07-28
 
 ### Added
@@ -291,7 +304,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.16...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.17...HEAD
+[0.1.17]: https://github.com/wiedymi/shu/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/wiedymi/shu/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/wiedymi/shu/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/wiedymi/shu/compare/v0.1.13...v0.1.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/scripts/design-proposal.sh
+++ b/scripts/design-proposal.sh
@@ -120,7 +120,7 @@ else
 fi
 printf '  '; accent; printf '→ '; reset; printf 'Downloading shu-darwin-arm64.tar.gz\n'
 printf '  '; accent; printf '[███████████······] '; reset; printf '4.2 MiB / 6.8 MiB  62%%\n'
-printf '  '; good; printf '✓ '; reset; printf 'Installed shu 0.1.16\n'
+printf '  '; good; printf '✓ '; reset; printf 'Updated shu to v0.1.16\n'
 printf '  '; label 'location'; printf '~/.local/bin/shu\n'
 printf '  '; label 'next'; printf 'shu --version\n'
 
@@ -213,7 +213,7 @@ muted; printf '  shu upgrade\n'; reset
 printf '  '; label 'version'; printf '0.1.15 → 0.1.16\n'
 printf '  '; accent; printf '… '; reset; printf 'Downloading shu-darwin-arm64.tar.gz\n'
 printf '  '; accent; printf '[███████████······] '; reset; printf '4.2 MiB / 6.8 MiB  62%%\n'
-printf '  '; good; printf '✓ '; reset; printf 'Updated shu to 0.1.16\n'
+printf '  '; good; printf '✓ '; reset; printf 'Updated shu to v0.1.16\n'
 printf '\n'
 accent; printf 'Version\n'; reset
 muted; printf '  shu --version\n'; reset

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -248,35 +248,38 @@ impl PickerTerminal {
             .skip(first_visible)
             .take(visible)
             .collect::<Vec<_>>();
+        // Raw mode disables the terminal's normal NL-to-CRLF conversion. Use
+        // CRLF explicitly so every logical row starts in column zero instead
+        // of continuing from the end of the preceding row.
         write!(
             self.stderr,
-            "{}\n\n",
+            "{}\r\n\r\n",
             "Pick a repository".with(Color::Cyan).bold()
         )?;
         write!(self.stderr, "{} ", " ".on(Color::Cyan))?;
         if query.is_empty() {
             write!(
                 self.stderr,
-                "{}\n\n",
+                "{}\r\n\r\n",
                 "Search repositories".with(Color::DarkGrey)
             )?;
         } else {
-            write!(self.stderr, "{query}\n\n")?;
+            write!(self.stderr, "{query}\r\n\r\n")?;
         }
         for (index, candidate) in visible_candidates.into_iter().enumerate() {
             let row = &candidate.identity;
             if first_visible + index == selected {
-                writeln!(
+                write!(
                     self.stderr,
-                    "{} {}  {}",
+                    "{} {}  {}\r\n",
                     "›".with(Color::Cyan).bold(),
                     fit_to_width(row, width.saturating_sub(8)).bold(),
                     candidate.location.symbol().with(Color::Cyan).bold(),
                 )?;
             } else {
-                writeln!(
+                write!(
                     self.stderr,
-                    "  {}  {}",
+                    "  {}  {}\r\n",
                     fit_to_width(row, width.saturating_sub(8)),
                     candidate.location.symbol().with(Color::Cyan),
                 )?;
@@ -288,7 +291,7 @@ impl PickerTerminal {
                 .unwrap_or_default();
             write!(
                 self.stderr,
-                "  {}{}\n\n",
+                "  {}{}\r\n\r\n",
                 fit_to_width(
                     &candidate.path.display().to_string(),
                     width.saturating_sub(4)
@@ -298,9 +301,9 @@ impl PickerTerminal {
             )?;
         }
         let count = candidates.len();
-        writeln!(
+        write!(
             self.stderr,
-            "{} {}   {} {}   {} {}",
+            "{} {}   {} {}   {} {}\r\n",
             "◆".with(Color::Cyan),
             "primary".with(Color::DarkGrey),
             "◇".with(Color::Cyan),
@@ -308,9 +311,9 @@ impl PickerTerminal {
             "⎇".with(Color::Cyan),
             "worktree".with(Color::DarkGrey),
         )?;
-        writeln!(
+        write!(
             self.stderr,
-            "{}  ·  {}",
+            "{}  ·  {}\r\n",
             format!("{count} matches").with(Color::DarkGrey),
             "↑↓ navigate  / filter  enter open  esc cancel".with(Color::DarkGrey),
         )?;

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 
 use crate::{cli::UpgradeArgs, hash::sha256_hex, http, ui};
 use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
 
 const RELEASE_REPOSITORY: &str = "wiedymi/shu";
 const PROGRESS_INTERVAL_BYTES: u64 = 256 * 1024;
@@ -25,17 +26,21 @@ pub fn upgrade(args: &UpgradeArgs) -> Result<()> {
     let target = release_target()?;
     let current = env::current_exe().context("could not determine Shu executable path")?;
     let asset = format!("shu-{target}{}", executable_extension());
-    let base = release_base(args.version.as_deref());
+    let client = http::agent();
+    let version = release_version(&client, args.version.as_deref())?;
+    let base = release_base(&version);
     ui::heading("Upgrade");
     ui::detail("platform", target);
-    ui::detail("release", args.version.as_deref().unwrap_or("latest"));
-    let client = http::agent();
-    ui::working("Downloading SHA256SUMS");
+    ui::detail(
+        "version",
+        format!("{} → {version}", env!("CARGO_PKG_VERSION")),
+    );
+    ui::working("Downloading release manifest");
     let manifest = get_text(&client, &format!("{base}/SHA256SUMS"))?;
     ui::working("Reading release manifest");
     let expected = checksum_for(&manifest, &asset)?;
-    ui::working(format!("Downloading {asset}"));
-    let binary = get_bytes(&client, &format!("{base}/{asset}"), &asset)?;
+    ui::action(format!("Downloading {asset}"));
+    let binary = get_bytes(&client, &format!("{base}/{asset}"))?;
     ui::working("Verifying checksum");
     verify_checksum(&binary, &expected, &asset)?;
 
@@ -50,7 +55,7 @@ pub fn upgrade(args: &UpgradeArgs) -> Result<()> {
     #[cfg(not(windows))]
     replace_now(&current, &staged)?;
 
-    ui::success("Downloaded verified Shu release");
+    ui::success(format!("Updated Shu to {version}"));
     #[cfg(windows)]
     ui::detail(
         "location",
@@ -62,16 +67,39 @@ pub fn upgrade(args: &UpgradeArgs) -> Result<()> {
 }
 
 /// Build a GitHub Release download base for the latest or one named release.
-fn release_base(version: Option<&str>) -> String {
-    match version {
-        None | Some("latest") => {
-            format!("https://github.com/{RELEASE_REPOSITORY}/releases/latest/download")
-        }
-        Some(version) => {
-            let tag = version.strip_prefix('v').unwrap_or(version);
-            format!("https://github.com/{RELEASE_REPOSITORY}/releases/download/v{tag}")
+fn release_base(version: &str) -> String {
+    format!("https://github.com/{RELEASE_REPOSITORY}/releases/download/{version}")
+}
+
+/// Resolve a named release or GitHub's current release to a visible tag.
+fn release_version(client: &ureq::Agent, requested: Option<&str>) -> Result<String> {
+    match requested.filter(|version| *version != "latest") {
+        Some(version) => Ok(normalize_tag(version)),
+        None => {
+            let response = http::get(
+                client,
+                &format!("https://api.github.com/repos/{RELEASE_REPOSITORY}/releases/latest"),
+                "latest release metadata",
+            )?;
+            let mut body = response.into_body();
+            let payload = body
+                .read_to_string()
+                .context("could not read latest release metadata")?;
+            let release: ReleaseMetadata = serde_json::from_str(&payload)
+                .context("could not parse latest release metadata")?;
+            Ok(normalize_tag(&release.tag_name))
         }
     }
+}
+
+/// Keep release URLs and human output consistently tag-shaped.
+fn normalize_tag(version: &str) -> String {
+    format!("v{}", version.trim_start_matches('v'))
+}
+
+#[derive(Deserialize)]
+struct ReleaseMetadata {
+    tag_name: String,
 }
 
 /// Return the release target matching the currently executing binary.
@@ -101,7 +129,7 @@ fn get_text(client: &ureq::Agent, url: &str) -> Result<String> {
 }
 
 /// Download a binary release asset while reporting its progress to the terminal.
-fn get_bytes(client: &ureq::Agent, url: &str, asset: &str) -> Result<Vec<u8>> {
+fn get_bytes(client: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
     let mut response = http::get(client, url, "release asset").with_context(|| {
             format!(
                 "release asset was unavailable: {url}. Check your internet connection and release access"
@@ -116,7 +144,7 @@ fn get_bytes(client: &ureq::Agent, url: &str, asset: &str) -> Result<Vec<u8>> {
         .and_then(|length| usize::try_from(length).ok())
         .unwrap_or_default();
     let mut bytes = Vec::with_capacity(capacity);
-    let mut progress = DownloadProgress::new(asset, content_length);
+    let mut progress = DownloadProgress::new(content_length);
     let mut reader = response.body_mut().as_reader();
     let mut buffer = [0_u8; 64 * 1024];
     loop {
@@ -134,9 +162,7 @@ fn get_bytes(client: &ureq::Agent, url: &str, asset: &str) -> Result<Vec<u8>> {
 }
 
 /// Render compact, rate-limited binary download progress on standard error.
-struct DownloadProgress<'a> {
-    /// Human-readable release asset name.
-    asset: &'a str,
+struct DownloadProgress {
     /// Advertised response size, when the server provides one.
     total: Option<u64>,
     /// Number of bytes received so far.
@@ -145,11 +171,10 @@ struct DownloadProgress<'a> {
     last_rendered: u64,
 }
 
-impl<'a> DownloadProgress<'a> {
+impl DownloadProgress {
     /// Create a reporter for one response body.
-    fn new(asset: &'a str, total: Option<u64>) -> Self {
+    fn new(total: Option<u64>) -> Self {
         Self {
-            asset,
             total,
             downloaded: 0,
             last_rendered: 0,
@@ -174,7 +199,7 @@ impl<'a> DownloadProgress<'a> {
 
     /// Rewrite one interactive line with the transferred byte count and percentage.
     fn render(&mut self) -> Result<()> {
-        ui::render_download_progress(self.asset, self.downloaded, self.total)?;
+        ui::render_download_progress(self.downloaded, self.total)?;
         self.last_rendered = self.downloaded;
         Ok(())
     }
@@ -269,10 +294,10 @@ mod tests {
     }
 
     #[test]
-    fn keeps_latest_and_normalizes_version_tags() {
-        assert!(release_base(None).ends_with("releases/latest/download"));
-        assert!(release_base(Some("0.1.0")).ends_with("releases/download/v0.1.0"));
-        assert!(release_base(Some("v0.1.0")).ends_with("releases/download/v0.1.0"));
+    fn normalizes_release_tags_for_download_urls() {
+        assert_eq!(normalize_tag("0.1.0"), "v0.1.0");
+        assert_eq!(normalize_tag("v0.1.0"), "v0.1.0");
+        assert!(release_base("v0.1.0").ends_with("releases/download/v0.1.0"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -106,25 +106,34 @@ pub fn accent(value: impl std::fmt::Display) -> String {
 }
 
 /// Draw byte-based download progress without inventing totals or percentages.
-pub fn render_download_progress(
-    asset: &str,
-    downloaded: u64,
-    total: Option<u64>,
-) -> std::io::Result<()> {
+pub fn render_download_progress(downloaded: u64, total: Option<u64>) -> std::io::Result<()> {
     if !stderr().is_terminal() {
         return Ok(());
     }
     let detail = match total.filter(|total| *total > 0) {
         Some(total) => format!(
-            "{} / {}  {}%",
+            "{}  {} / {}  {}%",
+            progress_bar(downloaded, total),
             human_size(downloaded),
             human_size(total),
-            downloaded.saturating_mul(100) / total
+            u128::from(downloaded) * 100 / u128::from(total)
         ),
         None => human_size(downloaded),
     };
-    eprint!("\r{} Downloading {asset}  {detail}", working_marker());
+    eprint!("\r  {detail}");
     stderr().flush()
+}
+
+/// Render a fixed-width bar from actual byte counts for a sized transfer.
+fn progress_bar(downloaded: u64, total: u64) -> String {
+    const WIDTH: u64 = 16;
+    let filled =
+        (u128::from(downloaded.min(total)) * u128::from(WIDTH) / u128::from(total)) as usize;
+    accent(format!(
+        "[{}{}]",
+        "█".repeat(filled),
+        "·".repeat(WIDTH as usize - filled)
+    ))
 }
 
 /// Format a byte count for compact human-facing progress.


### PR DESCRIPTION
## Summary
- correct raw-terminal picker line rendering
- show the resolved upgrade target version and a single byte-backed progress bar
- release Shu 0.1.17

## Validation
- cargo fmt --check
- cargo test --locked
- cargo clippy --locked --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --document-private-items
- Docker installer E2E