### PR TITLE
Clear upgrade progress before redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and releases use [Semantic Versioning](https://semver.org/).
   coverage, repeated CLI and Docker end-to-end runs, and semantic Windows path
   assertions.
 
+## [0.1.20] - 2026-07-28
+
+### Fixed
+
+- Clear the full terminal line before redrawing upgrade progress so stale
+  characters cannot remain beside the rendered percentage.
+
 ## [0.1.19] - 2026-07-28
 
 ### Changed
@@ -322,7 +329,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.19...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.20...HEAD
+[0.1.20]: https://github.com/wiedymi/shu/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/wiedymi/shu/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/wiedymi/shu/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/wiedymi/shu/compare/v0.1.16...v0.1.17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -120,7 +120,10 @@ pub fn render_download_progress(downloaded: u64, total: Option<u64>) -> std::io:
         ),
         None => human_size(downloaded),
     };
-    eprint!("\r  {detail}");
+    // A carriage return alone leaves trailing cells from an earlier frame in
+    // place on some terminals. Erase the entire line before drawing the next
+    // byte-accurate frame.
+    eprint!("\r\x1b[2K  {detail}");
     stderr().flush()
 }
 


### PR DESCRIPTION
Release Shu 0.1.20: clear the entire progress line before each redraw.