### PR TITLE
Add safe catalog remove command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and releases use [Semantic Versioning](https://semver.org/).
   coverage, repeated CLI and Docker end-to-end runs, and semantic Windows path
   assertions.
 
+## [0.1.21] - 2026-07-28
+
+### Added
+
+- `shu remove <repository>` as the clear, safe name for removing a repository
+  from Shu's catalog only; it never deletes a local checkout or remote.
+  `shu forget` remains a compatibility alias.
+
 ## [0.1.20] - 2026-07-28
 
 ### Fixed
@@ -329,7 +337,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.20...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.21...HEAD
+[0.1.21]: https://github.com/wiedymi/shu/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/wiedymi/shu/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/wiedymi/shu/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/wiedymi/shu/compare/v0.1.17...v0.1.18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,8 +87,9 @@ pub enum Commands {
     State(StateArgs),
     /// Mark a repository as archived without moving or deleting it.
     Archive(SelectorArgs),
-    /// Remove a repository from the catalog without deleting its local clone.
-    Forget(SelectorArgs),
+    /// Remove a repository from Shu's catalog without deleting its local clone or remote.
+    #[command(visible_alias = "forget")]
+    Remove(SelectorArgs),
     /// Interactively select a present local repository with Shu's fuzzy picker.
     Pick(PickArgs),
     /// Print shell integration that makes bare `shu` navigate into a selected repository.

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn run() -> Result<()> {
         Some(Commands::Archive(args)) => {
             commands::change_state(&cli, &args.selector, model::Lifecycle::Archived)
         }
-        Some(Commands::Forget(args)) => commands::forget(&cli, args),
+        Some(Commands::Remove(args)) => commands::forget(&cli, args),
         Some(Commands::Pick(args)) => commands::pick(&cli, args),
         Some(Commands::Shell(args)) => commands::shell(&args.command),
     }


### PR DESCRIPTION
Release Shu 0.1.21: add `shu remove` while retaining `shu forget` as an alias. This only removes catalog metadata; local clones and remotes are untouched.