### PR TITLE
Release 0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.23] - 2026-07-30
+
+### Fixed
+
+- Ignore Git worktree entries whose directories no longer exist so a stale
+  temporary worktree cannot prevent the repository picker from opening.
+
 ## [0.1.22] - 2026-07-28
 
 ### Added
@@ -352,7 +359,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.22...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.23...HEAD
+[0.1.23]: https://github.com/wiedymi/shu/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/wiedymi/shu/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/wiedymi/shu/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/wiedymi/shu/compare/v0.1.19...v0.1.20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"

--- a/src/git.rs
+++ b/src/git.rs
@@ -68,25 +68,36 @@ pub fn is_clean(path: &Path) -> Result<bool> {
 
 /// Return whether Git reports another linked working tree for this repository.
 pub fn has_linked_worktrees(path: &Path) -> Result<bool> {
-    Ok(worktrees(path)?.len() > 1)
+    Ok(reported_worktrees(path)?.len() > 1)
 }
 
-/// Return every working-tree path Git associates with a local repository.
+/// Return every present working-tree path Git associates with a local repository.
 ///
 /// The first entry is normally the main working tree and later entries are
 /// linked worktrees. Paths are read from Git each time so Shu never stores
-/// worktree state in `shu.toml`.
+/// worktree state in `shu.toml`. Git may retain prunable entries after a
+/// temporary worktree disappears; those absent paths cannot be picked and do
+/// not prevent the remaining repositories from being used.
 pub fn worktrees(path: &Path) -> Result<Vec<PathBuf>> {
-    output(path, ["worktree", "list", "--porcelain"])?
+    reported_worktrees(path)?
+        .into_iter()
+        .map(|path| match fs::canonicalize(&path) {
+            Ok(path) => Ok(Some(presentation_path(path))),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error)
+                .with_context(|| format!("could not resolve Git worktree {}", path.display())),
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|paths| paths.into_iter().flatten().collect())
+}
+
+/// Return every worktree path in Git's metadata, including prunable entries.
+fn reported_worktrees(path: &Path) -> Result<Vec<PathBuf>> {
+    Ok(output(path, ["worktree", "list", "--porcelain"])?
         .lines()
         .filter_map(|line| line.strip_prefix("worktree "))
-        .map(|value| {
-            let path = PathBuf::from(value);
-            fs::canonicalize(&path)
-                .map(presentation_path)
-                .with_context(|| format!("could not resolve Git worktree {}", path.display()))
-        })
-        .collect()
+        .map(PathBuf::from)
+        .collect())
 }
 
 /// Run Git in a working directory and return trimmed standard output on success.

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -875,13 +875,14 @@ fn picker_ignores_a_reported_worktree_with_a_missing_path() {
     );
     run_git(&fixture.seed, ["worktree", "lock"], Some(&linked));
     fs::remove_dir_all(&linked).unwrap();
-    assert!(
-        normalize_path(&run_git_output(
-            &fixture.seed,
-            ["worktree", "list", "--porcelain"]
-        ))
-        .contains(&normalize_path(linked.to_str().unwrap())),
-        "the regression requires Git to retain the missing worktree"
+    let reported = run_git_output(&fixture.seed, ["worktree", "list", "--porcelain"]);
+    assert_eq!(
+        reported
+            .lines()
+            .filter(|line| line.starts_with("worktree "))
+            .count(),
+        2,
+        "the regression requires Git to retain the missing worktree:\n{reported}"
     );
 
     let picked = fixture.shu([

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -855,7 +855,7 @@ fn records_multiple_clones_in_the_catalog_and_discovers_git_worktrees() {
 }
 
 #[test]
-fn picker_ignores_a_prunable_worktree_with_a_missing_path() {
+fn picker_ignores_a_reported_worktree_with_a_missing_path() {
     let fixture = Fixture::new();
     let catalog = fixture.write_catalog("library.toml");
     let linked = fixture.temp.path().join("missing-worktree");
@@ -873,6 +873,7 @@ fn picker_ignores_a_prunable_worktree_with_a_missing_path() {
         ["worktree", "add", "--detach"],
         Some(&linked),
     );
+    run_git(&fixture.seed, ["worktree", "lock"], Some(&linked));
     fs::remove_dir_all(&linked).unwrap();
     assert!(
         normalize_path(&run_git_output(

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -875,8 +875,11 @@ fn picker_ignores_a_prunable_worktree_with_a_missing_path() {
     );
     fs::remove_dir_all(&linked).unwrap();
     assert!(
-        run_git_output(&fixture.seed, ["worktree", "list", "--porcelain"])
-            .contains(linked.to_str().unwrap()),
+        normalize_path(&run_git_output(
+            &fixture.seed,
+            ["worktree", "list", "--porcelain"]
+        ))
+        .contains(&normalize_path(linked.to_str().unwrap())),
         "the regression requires Git to retain the missing worktree"
     );
 

--- a/tests/cli_workflows.rs
+++ b/tests/cli_workflows.rs
@@ -855,6 +855,47 @@ fn records_multiple_clones_in_the_catalog_and_discovers_git_worktrees() {
 }
 
 #[test]
+fn picker_ignores_a_prunable_worktree_with_a_missing_path() {
+    let fixture = Fixture::new();
+    let catalog = fixture.write_catalog("library.toml");
+    let linked = fixture.temp.path().join("missing-worktree");
+
+    fixture
+        .shu([
+            "--catalog",
+            catalog.to_str().unwrap(),
+            "add",
+            fixture.seed.to_str().unwrap(),
+        ])
+        .assert_success();
+    run_git(
+        &fixture.seed,
+        ["worktree", "add", "--detach"],
+        Some(&linked),
+    );
+    fs::remove_dir_all(&linked).unwrap();
+    assert!(
+        run_git_output(&fixture.seed, ["worktree", "list", "--porcelain"])
+            .contains(linked.to_str().unwrap()),
+        "the regression requires Git to retain the missing worktree"
+    );
+
+    let picked = fixture.shu([
+        "--catalog",
+        catalog.to_str().unwrap(),
+        "pick",
+        "--filter",
+        "api",
+        "--path-only",
+    ]);
+    picked.assert_success();
+    assert_same_path(
+        String::from_utf8(picked.stdout).unwrap().trim(),
+        &fixture.seed,
+    );
+}
+
+#[test]
 fn migrates_a_clean_repository_into_shus_canonical_layout() {
     let fixture = Fixture::new();
     let catalog = fixture.write_empty_catalog("library.toml");


### PR DESCRIPTION
## Summary

- ignore Git worktree entries whose directories no longer exist when building picker candidates
- keep migration safety based on every worktree Git still reports
- add regression coverage for prunable temporary worktrees
- release as Shu 0.1.23

## Validation

- `cargo fmt --check`
- `cargo test --locked` (19 unit tests, 26 CLI workflows)
- `cargo clippy --locked --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --document-private-items`
- `docker build --tag shu:test .`
- Docker `tests/docker/e2e.sh`
- interactive smoke: bare `shu` and `shu pick` both open against the real stale `/private/tmp/shu-release-0.1.21` metadata