### PR TITLE
Respect XDG_CONFIG_HOME on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect `XDG_CONFIG_HOME` for the default catalog path on macOS while
+  preserving the native Application Support location when it is unset.
+
 ## [0.1.23] - 2026-07-30
 
 ### Fixed

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashSet,
+    ffi::OsString,
     fs,
     path::{Path, PathBuf},
 };
@@ -18,10 +19,23 @@ use serde::Serialize;
 
 /// Return the active catalog path, honoring the global `--catalog` override.
 pub fn catalog_path(cli: &Cli) -> Result<PathBuf> {
-    Ok(cli
-        .catalog
-        .clone()
-        .unwrap_or_else(|| dirs().unwrap().config_dir().join("shu.toml")))
+    match &cli.catalog {
+        Some(path) => Ok(path.clone()),
+        None => default_catalog_path(std::env::var_os("XDG_CONFIG_HOME")),
+    }
+}
+
+/// Return the environment- or platform-selected catalog path.
+fn default_catalog_path(xdg_config_home: Option<OsString>) -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    if let Some(config_home) = xdg_config_home {
+        return Ok(PathBuf::from(config_home).join("shu").join("shu.toml"));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = xdg_config_home;
+
+    Ok(dirs()?.config_dir().join("shu.toml"))
 }
 
 /// Load and validate the selected catalog, returning its path and parsed data.
@@ -333,13 +347,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn explicit_catalog_takes_precedence_over_the_default() {
+        let path = PathBuf::from("custom/shu.toml");
+        let cli = Cli {
+            catalog: Some(path.clone()),
+            json: false,
+            non_interactive: false,
+            yes: false,
+            command: None,
+        };
+
+        assert_eq!(catalog_path(&cli).unwrap(), path);
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
-    fn uses_the_com_wiedymi_shu_application_identifier() {
+    fn uses_xdg_config_home_for_the_catalog() {
+        assert_eq!(
+            default_catalog_path(Some(OsString::from("/tmp/shu-xdg"))).unwrap(),
+            PathBuf::from("/tmp/shu-xdg/shu/shu.toml")
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn uses_the_com_wiedymi_shu_application_identifier_without_xdg_config_home() {
         assert!(
-            dirs()
+            default_catalog_path(None)
                 .unwrap()
-                .config_dir()
                 .to_string_lossy()
                 .contains("com.wiedymi.shu")
         );


### PR DESCRIPTION
## Summary

- use `$XDG_CONFIG_HOME/shu/shu.toml` as the default catalog path on macOS when `XDG_CONFIG_HOME` is set
- preserve the native Application Support path when the variable is unset
- keep an explicit `--catalog` path at highest precedence
- add focused path-resolution tests and an unreleased changelog entry

## Root cause

Catalog resolution always delegated to `directories::ProjectDirs` on macOS, so it never considered the XDG override already supported by Shu's shell configuration behavior.

## Impact

macOS users who opt into an XDG configuration root can keep Shu's catalog alongside their other XDG-aware tools without changing the existing default for everyone else.

## Validation

- `git diff --check`
- verified the remote branch is one commit ahead of `main` and changes only `src/catalog.rs` and `CHANGELOG.md`
- local Rust checks were not available in the workspace; the repository CI matrix will run formatting, Clippy, tests, docs, and release builds on macOS, Linux, and Windows

Closes #28