### PR TITLE
Speed up repository picker startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Make the repository picker start promptly on larger catalogs by observing
+  each checkout once and running independent Git worktree lookups concurrently.
+
 ### Fixed
 
 - Respect `XDG_CONFIG_HOME` for the default catalog path on macOS while

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -4,9 +4,10 @@ use std::{
     cmp::Reverse,
     io::{Write, stderr},
     path::PathBuf,
+    thread,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 use crossterm::{
     cursor::{Hide, MoveTo, Show},
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -25,13 +26,7 @@ use crate::{
 /// Interactively select a present local repository with Shu's built-in fuzzy picker.
 pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
     let (_, catalog) = catalog::load_or_initialize(cli)?;
-    let candidates = catalog::filtered(&catalog, &args.filter)?
-        .into_iter()
-        .map(|repo| candidates(&catalog, repo))
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let candidates = all_candidates(&catalog, catalog::filtered(&catalog, &args.filter)?)?;
     if candidates.is_empty() {
         bail!(
             "no catalogued repositories are available locally. Run `shu status` to see expected or recorded paths; use `shu ensure <repository>` to clone one, or run `shu add .` from an existing clone to record it"
@@ -53,6 +48,43 @@ pub fn pick(cli: &Cli, args: &PickArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Observe independent repositories concurrently without overwhelming the machine.
+fn all_candidates(catalog: &crate::model::Catalog, repos: Vec<&Repo>) -> Result<Vec<Candidate>> {
+    const MAX_WORKERS: usize = 8;
+
+    if repos.is_empty() {
+        return Ok(Vec::new());
+    }
+    let workers = thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(MAX_WORKERS)
+        .min(repos.len());
+    let chunk_size = repos.len().div_ceil(workers);
+    thread::scope(|scope| {
+        let handles = repos
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .map(|repo| candidates(catalog, repo))
+                        .collect::<Result<Vec<_>>>()
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut observed = Vec::new();
+        for handle in handles {
+            observed.extend(
+                handle
+                    .join()
+                    .map_err(|_| anyhow!("repository observation worker panicked"))??,
+            );
+        }
+        Ok(observed.into_iter().flatten().collect())
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -83,32 +115,87 @@ impl LocationKind {
 
 /// Convert each present clone and Git worktree into a searchable picker candidate.
 fn candidates(catalog: &crate::model::Catalog, repo: &Repo) -> Result<Vec<Candidate>> {
-    let clones = locations::present_paths(catalog, repo)?;
-    let primary = locations::present_path(catalog, repo)?;
-    locations::pickable_paths(catalog, repo).map(|paths| {
-        paths
-            .into_iter()
-            .map(|path| {
-                let location = if primary.as_ref().is_some_and(|primary| primary == &path) {
-                    LocationKind::Primary
-                } else if clones.contains(&path) {
-                    LocationKind::Checkout
-                } else {
-                    LocationKind::Worktree
-                };
-                let branch = (location == LocationKind::Worktree)
-                    .then(|| git::output(&path, ["branch", "--show-current"]).ok())
-                    .flatten()
-                    .filter(|branch| !branch.is_empty());
-                Candidate {
-                    identity: repo.source.clone(),
-                    location,
-                    branch,
-                    path,
+    let primary = locations::primary_path(catalog, repo)?;
+    let mut clone_paths = locations::remembered_paths(catalog, repo)?;
+    push_unique(&mut clone_paths, locations::managed_path(catalog, repo)?);
+
+    let mut probes = clone_paths
+        .iter()
+        .cloned()
+        .map(|path| (path, true))
+        .collect::<Vec<_>>();
+    if let Some(primary) = &primary
+        && !clone_paths.contains(primary)
+    {
+        probes.push((primary.clone(), false));
+    }
+
+    let mut clones = Vec::new();
+    let mut worktrees = Vec::new();
+    let mut primary_is_present = false;
+    for (path, is_clone) in probes {
+        let Some(observed) = git::inspect_worktrees(&path)? else {
+            continue;
+        };
+        if primary.as_ref() == Some(&path) {
+            primary_is_present = true;
+        }
+        if is_clone {
+            push_unique(&mut clones, path);
+            for worktree in observed {
+                if !worktrees
+                    .iter()
+                    .any(|known: &git::Worktree| known.path == worktree.path)
+                {
+                    worktrees.push(worktree);
                 }
-            })
-            .collect()
-    })
+            }
+        }
+    }
+
+    let primary = primary.filter(|_| primary_is_present);
+    let mut candidates = Vec::new();
+    if let Some(primary) = &primary {
+        candidates.push(Candidate {
+            identity: repo.source.clone(),
+            location: LocationKind::Primary,
+            branch: None,
+            path: primary.clone(),
+        });
+    }
+    for clone in clones {
+        if primary.as_ref() != Some(&clone) {
+            candidates.push(Candidate {
+                identity: repo.source.clone(),
+                location: LocationKind::Checkout,
+                branch: None,
+                path: clone,
+            });
+        }
+    }
+    for worktree in worktrees {
+        if primary.as_ref() == Some(&worktree.path)
+            || candidates
+                .iter()
+                .any(|candidate| candidate.path == worktree.path)
+        {
+            continue;
+        }
+        candidates.push(Candidate {
+            identity: repo.source.clone(),
+            location: LocationKind::Worktree,
+            branch: worktree.branch,
+            path: worktree.path,
+        });
+    }
+    Ok(candidates)
+}
+
+/// Append one path unless the same location is already known.
+fn push_unique(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
 }
 
 /// Run a raw-key terminal interface until the user selects a candidate or cancels.

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,6 +12,15 @@ use std::{
 use crate::identity::normalize_identity;
 use anyhow::{Context, Result, anyhow, bail};
 
+/// One accessible working tree reported by Git.
+#[derive(Debug)]
+pub struct Worktree {
+    /// Canonical filesystem location of the working tree.
+    pub path: PathBuf,
+    /// Checked-out local branch, or `None` when the working tree is detached.
+    pub branch: Option<String>,
+}
+
 /// Return whether a path is an accessible Git working tree.
 pub fn is_repo(path: &Path) -> bool {
     output(path, ["rev-parse", "--is-inside-work-tree"]).is_ok_and(|value| value == "true")
@@ -79,35 +88,81 @@ pub fn has_linked_worktrees(path: &Path) -> Result<bool> {
 /// temporary worktree disappears; those absent paths cannot be picked and do
 /// not prevent the remaining repositories from being used.
 pub fn worktrees(path: &Path) -> Result<Vec<PathBuf>> {
-    reported_worktrees(path)?
+    Ok(accessible_worktrees(reported_worktrees(path)?)?
         .into_iter()
-        .map(|path| match fs::canonicalize(&path) {
-            Ok(path) => Ok(Some(presentation_path(path))),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error)
-                .with_context(|| format!("could not resolve Git worktree {}", path.display())),
-        })
-        .collect::<Result<Vec<_>>>()
-        .map(|paths| paths.into_iter().flatten().collect())
+        .map(|worktree| worktree.path)
+        .collect())
+}
+
+/// Observe an accessible repository and all of its working trees in one Git call.
+///
+/// A non-repository path returns `None`. Failures to start Git or decode its
+/// successful response remain errors so callers do not mistake a broken Git
+/// installation for an absent checkout.
+pub fn inspect_worktrees(path: &Path) -> Result<Option<Vec<Worktree>>> {
+    if !path.is_dir() {
+        return Ok(None);
+    }
+    let output = command_output(path, ["worktree", "list", "--porcelain"])?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let worktrees = parse_worktrees(&String::from_utf8(output.stdout)?)?;
+    accessible_worktrees(worktrees).map(Some)
 }
 
 /// Return every worktree path in Git's metadata, including prunable entries.
-fn reported_worktrees(path: &Path) -> Result<Vec<PathBuf>> {
-    Ok(output(path, ["worktree", "list", "--porcelain"])?
-        .lines()
-        .filter_map(|line| line.strip_prefix("worktree "))
-        .map(PathBuf::from)
-        .collect())
+fn reported_worktrees(path: &Path) -> Result<Vec<Worktree>> {
+    parse_worktrees(&output(path, ["worktree", "list", "--porcelain"])?)
+}
+
+/// Parse Git's worktree porcelain records, retaining branch facts needed by the picker.
+fn parse_worktrees(output: &str) -> Result<Vec<Worktree>> {
+    let mut worktrees: Vec<Worktree> = Vec::new();
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            worktrees.push(Worktree {
+                path: PathBuf::from(path),
+                branch: None,
+            });
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            let worktree = worktrees
+                .last_mut()
+                .ok_or_else(|| anyhow!("Git reported a worktree branch before its path"))?;
+            worktree.branch = Some(
+                branch
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(branch)
+                    .to_owned(),
+            );
+        } else if line == "bare" {
+            worktrees.pop();
+        }
+    }
+    Ok(worktrees)
+}
+
+/// Canonicalize Git's reported worktrees and ignore paths retained only as stale metadata.
+fn accessible_worktrees(worktrees: Vec<Worktree>) -> Result<Vec<Worktree>> {
+    worktrees
+        .into_iter()
+        .map(|mut worktree| match fs::canonicalize(&worktree.path) {
+            Ok(path) => {
+                worktree.path = presentation_path(path);
+                Ok(Some(worktree))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error).with_context(|| {
+                format!("could not resolve Git worktree {}", worktree.path.display())
+            }),
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(|worktrees| worktrees.into_iter().flatten().collect())
 }
 
 /// Run Git in a working directory and return trimmed standard output on success.
 pub fn output<const N: usize>(dir: &Path, args: [&str; N]) -> Result<String> {
-    let result = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(args)
-        .output()
-        .with_context(|| "could not run git; ensure Git is installed")?;
+    let result = command_output(dir, args)?;
     if !result.status.success() {
         bail!(
             "git command failed in {}: {}",
@@ -116,6 +171,16 @@ pub fn output<const N: usize>(dir: &Path, args: [&str; N]) -> Result<String> {
         );
     }
     Ok(String::from_utf8(result.stdout)?.trim().to_owned())
+}
+
+/// Run one Git subprocess while leaving command-specific status handling to the caller.
+fn command_output<const N: usize>(dir: &Path, args: [&str; N]) -> Result<std::process::Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .with_context(|| "could not run git; ensure Git is installed")
 }
 
 /// Compatibility alias for [`output`], used by catalog code.
@@ -238,4 +303,30 @@ pub fn initialize(target: &Path) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_worktree_branches_and_detached_heads() {
+        let worktrees = parse_worktrees(
+            "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo/feature\nHEAD def\nbranch refs/heads/feature/fast\n\nworktree /repo/detached\nHEAD 123\ndetached\n",
+        )
+        .unwrap();
+
+        assert_eq!(worktrees.len(), 3);
+        assert_eq!(worktrees[0].path, PathBuf::from("/repo"));
+        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+        assert_eq!(worktrees[1].branch.as_deref(), Some("feature/fast"));
+        assert_eq!(worktrees[2].branch, None);
+    }
+
+    #[test]
+    fn excludes_bare_repositories_from_working_tree_results() {
+        let worktrees = parse_worktrees("worktree /repo.git\nHEAD abc\nbare\n").unwrap();
+
+        assert!(worktrees.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- observe each checkout once instead of repeatedly spawning Git
- reuse worktree porcelain output for paths and branches
- run independent checkout observations with bounded parallelism

## Performance

- picker startup: 2.62 s -> 56 ms on a 36-repository catalog
- Git subprocesses: 253 -> 36

## Validation

- cargo fmt --check
- cargo test --locked
- cargo clippy --locked --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --document-private-items