### PR TITLE
Reject invalid XDG_CONFIG_HOME values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Respect `XDG_CONFIG_HOME` for the default catalog path on macOS while
-  preserving the native Application Support location when it is unset.
+- Respect an absolute `XDG_CONFIG_HOME` for the default catalog path on macOS,
+  preserve the native Application Support location when it is unset or
+  invalid, and prevent invalid XDG values from making shell paths relative.
 
 ## [0.1.23] - 2026-07-30
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -28,8 +28,8 @@ pub fn catalog_path(cli: &Cli) -> Result<PathBuf> {
 /// Return the environment- or platform-selected catalog path.
 fn default_catalog_path(xdg_config_home: Option<OsString>) -> Result<PathBuf> {
     #[cfg(target_os = "macos")]
-    if let Some(config_home) = xdg_config_home {
-        return Ok(PathBuf::from(config_home).join("shu").join("shu.toml"));
+    if let Some(config_home) = crate::paths::valid_xdg_config_home(xdg_config_home) {
+        return Ok(config_home.join("shu").join("shu.toml"));
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -368,6 +368,16 @@ mod tests {
             default_catalog_path(Some(OsString::from("/tmp/shu-xdg"))).unwrap(),
             PathBuf::from("/tmp/shu-xdg/shu/shu.toml")
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ignores_empty_and_relative_xdg_config_homes_for_the_catalog() {
+        let native = default_catalog_path(None).unwrap();
+
+        for value in [OsString::new(), OsString::from("relative/config")] {
+            assert_eq!(default_catalog_path(Some(value)).unwrap(), native);
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -1,7 +1,9 @@
 //! Persistent shell integration for repository navigation.
 
 use std::{
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -64,7 +66,7 @@ fn default_profile(shell: Shell) -> Result<PathBuf> {
             .map(PathBuf::from)
             .unwrap_or(home)
             .join(".zshrc")),
-        Shell::Fish => Ok(config_home(&home)
+        Shell::Fish => Ok(config_home(&home, env::var_os("XDG_CONFIG_HOME"))
             .join("fish")
             .join("conf.d")
             .join("shu.fish")),
@@ -104,7 +106,9 @@ fn nushell_profile(home: &Path) -> Result<PathBuf> {
             return Ok(PathBuf::from(value));
         }
     }
-    Ok(config_home(home).join("nushell").join("config.nu"))
+    Ok(config_home(home, env::var_os("XDG_CONFIG_HOME"))
+        .join("nushell")
+        .join("config.nu"))
 }
 
 /// Add or replace Shu's marked integration block without touching other configuration.
@@ -155,10 +159,8 @@ fn home_dir() -> Result<PathBuf> {
 }
 
 /// Return the user configuration root while honoring the XDG override when present.
-fn config_home(home: &Path) -> PathBuf {
-    env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".config"))
+fn config_home(home: &Path, xdg_config_home: Option<OsString>) -> PathBuf {
+    crate::paths::valid_xdg_config_home(xdg_config_home).unwrap_or_else(|| home.join(".config"))
 }
 
 /// Return a friendly name for setup output.
@@ -270,6 +272,29 @@ mod tests {
     #[test]
     fn powershell_wrapper_selects_a_single_path_from_native_command_output() {
         assert!(POWERSHELL_SCRIPT.contains("Select-Object -Last 1"));
+    }
+
+    #[test]
+    fn config_home_ignores_missing_empty_and_relative_xdg_values() {
+        let home = PathBuf::from("home");
+        for value in [
+            None,
+            Some(OsString::new()),
+            Some(OsString::from("relative/config")),
+        ] {
+            assert_eq!(config_home(&home, value), home.join(".config"));
+        }
+    }
+
+    #[test]
+    fn config_home_uses_an_absolute_xdg_value() {
+        let home = PathBuf::from("home");
+        let path = std::env::current_dir().unwrap().join("xdg-config");
+
+        assert_eq!(
+            config_home(&home, Some(path.clone().into_os_string())),
+            path
+        );
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,6 +1,9 @@
-//! Repository-root expansion and canonical local-path construction.
+//! Filesystem-path validation, expansion, and canonical local-path construction.
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     identity::normalize_identity,
@@ -25,6 +28,11 @@ pub fn absolute(path: &Path) -> Result<PathBuf> {
     }
 }
 
+/// Return an XDG configuration root only when its environment value is absolute.
+pub fn valid_xdg_config_home(value: Option<OsString>) -> Option<PathBuf> {
+    value.map(PathBuf::from).filter(|path| path.is_absolute())
+}
+
 /// Expand `~`, `~/`, and `~\\` prefixes using the current user's home directory.
 fn expand_home(value: &str) -> Result<PathBuf> {
     if value == "~" || value.starts_with("~/") || value.starts_with("~\\") {
@@ -35,4 +43,30 @@ fn expand_home(value: &str) -> Result<PathBuf> {
         return Ok(home.join(value[2..].replace('/', std::path::MAIN_SEPARATOR_STR)));
     }
     Ok(PathBuf::from(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_missing_empty_and_relative_xdg_config_homes() {
+        for value in [
+            None,
+            Some(OsString::new()),
+            Some(OsString::from("relative/config")),
+        ] {
+            assert_eq!(valid_xdg_config_home(value), None);
+        }
+    }
+
+    #[test]
+    fn accepts_an_absolute_xdg_config_home() {
+        let path = std::env::current_dir().unwrap().join("xdg-config");
+
+        assert_eq!(
+            valid_xdg_config_home(Some(path.clone().into_os_string())),
+            Some(path)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- accept `XDG_CONFIG_HOME` only when it contains an absolute path
- fall back to macOS Application Support for invalid catalog values
- fall back to `~/.config` for invalid Fish and Nushell configuration values
- add parallel-safe regression tests for missing, empty, relative, and absolute values
- update the unreleased changelog entry

## Root cause

`std::env::var_os` returns `Some` for empty and relative values. Those values were converted directly into paths, allowing Shu to derive catalog or shell configuration files relative to the current working directory.

## Impact

Invalid XDG configuration can no longer make Shu read or create a different catalog or shell startup file depending on where the command is run.

## Review context

Addresses the [Codex review finding on PR #29](https://github.com/wiedymi/shu/pull/29#discussion_r3698785777).

## Validation

- `git diff --check`
- rebased onto current `main` and verified as one commit ahead with only the intended files changed
- local Rust tooling is unavailable in this workspace; the repository CI matrix will run formatting, Clippy, tests, docs, platform builds, Docker E2E, and RustSec