### PR TITLE
Release 0.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.24] - 2026-08-02
+
 ### Changed
 
 - Make the repository picker start promptly on larger catalogs by observing
   each checkout once and running independent Git worktree lookups concurrently.
+- Add an inline README showcase video for Shu's everyday repository workflow.
 
 ### Fixed
 
@@ -370,7 +373,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.23...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.24...HEAD
+[0.1.24]: https://github.com/wiedymi/shu/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/wiedymi/shu/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/wiedymi/shu/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/wiedymi/shu/compare/v0.1.20...v0.1.21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"


### PR DESCRIPTION
## Summary

- release the faster repository picker
- respect validated XDG_CONFIG_HOME catalog and shell paths
- include the inline README showcase in the curated changelog
- bump Cargo.toml and Cargo.lock to 0.1.24

## Review

Reviewed commits 64464f0, ad71392, and 6659b42 together. No release-blocking findings remained after the invalid XDG value follow-up.

## Validation

- cargo fmt --check
- cargo test --locked (28 unit tests, 26 CLI workflows)
- cargo clippy --locked --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --document-private-items
- docker build --tag shu:test .
- Docker installer E2E via tests/docker/e2e.sh