### PR TITLE
Release 0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-08-03
+
+### Changed
+
+- Update the TOML parser dependency to its latest compatible patch release.
+
 ### Fixed
 
 - Redraw repository picker frames without exposing a cleared screen between
@@ -378,7 +384,8 @@ and releases use [Semantic Versioning](https://semver.org/).
 - Built-in fuzzy repository picker and shell navigation wrappers.
 - Offline CLI integration tests and Docker end-to-end coverage.
 
-[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.24...HEAD
+[Unreleased]: https://github.com/wiedymi/shu/compare/v0.1.25...HEAD
+[0.1.25]: https://github.com/wiedymi/shu/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/wiedymi/shu/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/wiedymi/shu/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/wiedymi/shu/compare/v0.1.21...v0.1.22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shu"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shu"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 rust-version = "1.88"
 description = "A tiny, declarative, agent-friendly repository library"


### PR DESCRIPTION
## Release contents

- prevent repository-picker flicker during navigation and filtering (#34)
- update toml to 1.1.4 and toml_parser to 1.1.3 (#33)
- set Cargo package and lockfile versions to 0.1.25
- publish the dated 0.1.25 changelog section and comparison links

## Validation

- cargo fmt --check
- cargo test --locked (29 unit tests, 26 CLI workflow tests)
- cargo clippy --locked --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --document-private-items
- docker build --tag shu:test .
- docker image readback: shu 0.1.25
- Docker end-to-end installer/workflow suite