### PR TITLE
Add optional Shu agent skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and releases use [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- An optional portable agent skill that teaches compatible coding agents to
+  recognize repository-library tasks and use Shu's safe, self-described
+  workflows.
+
 ## [0.1.25] - 2026-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ from source instead:
 cargo install --git https://github.com/wiedymi/shu
 ```
 
+### Optional agent skill
+
+Shu works with coding agents through its normal help and structured output.
+Install the optional [Shu skill](skills/shu/SKILL.md) globally when you also
+want compatible agents to recognize repository-library tasks and choose Shu
+automatically:
+
+```sh
+npx skills add wiedymi/shu --skill shu -g
+```
+
 ## Start here
 
 Add a project you already have, or clone one you want. Shu creates its local

--- a/skills/shu/SKILL.md
+++ b/skills/shu/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: shu
+description: Manage a user's Git repository library through the Shu CLI. Use when the user mentions Shu or shu.toml, asks to work with their repository library, or asks to locate, restore, audit, organize, migrate, classify, or clone top-level repositories across their machine.
+---
+
+# Use Shu
+
+Use Shu as the repository-library layer. Use ordinary Git commands for work
+inside a checkout, such as branches, commits, rebases, and worktrees.
+
+## Establish the current contract
+
+1. Verify that `shu --version` succeeds. If Shu is unavailable, report that and
+   install it only when the user asks.
+2. Read `shu --help` and the relevant `shu <command> --help` before acting.
+   Treat the installed CLI as the version-specific source of truth rather than
+   relying on copied command documentation.
+3. Start with read-only inspection. Prefer stable JSON from `doctor`, `list`,
+   `status`, and `scan` without `--add`; do not assume other commands support
+   JSON.
+4. Use the active catalog unless the user supplies a specific `--catalog`.
+
+## Resolve and restore repositories
+
+- Use `shu path <selector>` when the checkout must already exist.
+- Use `shu ensure <selector> --path-only` when a missing catalogued repository
+  may need to be cloned. Keep the returned path on stdout suitable for scripts.
+- Use `shu --json list` to resolve ambiguity, and prefer the full repository
+  identity when selecting among similarly named repositories.
+- Avoid the interactive picker in unattended work. Use selectors, filters, and
+  path-only or JSON output instead.
+
+## Audit and organize repositories
+
+- Scan bounded, known source roots rather than an entire home directory or
+  filesystem. Use `shu --json scan <root>` for read-only discovery.
+- Supplement Shu with focused Git inspection when the user requests a complete
+  audit that must include repositories intentionally omitted by normal scans,
+  such as hidden dependency trees, submodules, or shallow clones.
+- Classify and report candidates before making bulk catalog or filesystem
+  changes. Preserve the user's stated exclusions across follow-up work.
+- Prefer Shu commands over editing `shu.toml`. Edit the catalog directly only
+  when the requested catalog feature has no CLI command, preserve unknown
+  fields, and validate it with `shu --json doctor` afterward.
+
+## Change the library safely
+
+- Use `shu add .` to record an existing checkout without moving it. Use
+  `shu add <remote-identity>` when the user wants Shu to clone and catalogue a
+  top-level repository.
+- Treat migration as a separate filesystem-moving operation. Run
+  `shu --non-interactive add <path> --migrate --dry-run`, report the result,
+  and obtain approval for the exact candidates. Immediately repeat each
+  dry-run before executing its migration with `--yes`, and migrate sequentially.
+- Never manually move a repository to bypass a failed migration preflight.
+  Leave dirty repositories, live linked worktrees, occupied destinations, and
+  other rejected candidates untouched.
+- Use `shu remove <selector>` only to remove a catalog entry. Do not describe it
+  as deleting the local checkout or remote repository.
+- Treat `shu sync` as publication to the configured catalog remote. Run it only
+  when the user explicitly requests that publication, and report local catalog
+  changes that remain unsynced.
+
+## Preserve user intent
+
+- Keep read-only investigation read-only until the user authorizes changes.
+- Do not expand an approved repository set because additional candidates are
+  technically eligible.
+- Do not delete, reset, clean, move, or publish repositories unless the user
+  explicitly requested that effect.


### PR DESCRIPTION
## Summary

- add a portable `skills/shu/SKILL.md` that helps agents recognize repository-library work and use Shu safely
- keep the installed CLI and its command help as the version-specific source of truth
- document optional global installation with the cross-agent `skills` CLI
- record the new capability under `Unreleased`

## Design

The skill is intentionally a thin activation and policy layer. It does not duplicate the command reference, bundle scripts, add Shu-owned installation state, or change normal Git workflows inside a checkout.

It emphasizes read-only inspection, deterministic output, bounded audits, dry-run-first migration, exact scope preservation, and explicit catalog publication.

## Validation

- `skills add . --list` with Node.js 22.20.0, confirming exactly one discoverable `shu` skill (the latest `skills` package requires Node.js 22.20+)
- `git diff --check`
- `cargo fmt --check`
- `cargo test --locked` (55 tests)
- `cargo clippy --locked --all-targets -- -D warnings`
